### PR TITLE
GHPMetadataGenerator: Don't overwrite site.github if it's already set.

### DIFF
--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -5,7 +5,15 @@ module Jekyll
     class GHPMetadataGenerator < Jekyll::Generator
       def generate(site)
         GitHubMetadata.repository = GitHubMetadata::Repository.new(site.config.fetch('repository'))
-        site.config['github'] = GitHubMetadata.to_liquid
+        site.config['github'] =
+          case site.config['github']
+          when nil
+            GitHubMetadata.to_liquid
+          when Hash
+            Jekyll::Utils.deep_merge_hashes(GitHubMetadata.to_liquid, site.config['github'])
+          else
+            site.config['github']
+          end
       end
     end
   end

--- a/spec/test-site/_config.yml
+++ b/spec/test-site/_config.yml
@@ -1,3 +1,6 @@
 repository: jekyll/github-metadata
+github:
+  in_your_config:
+    setting_your: keyz
 gems:
   - jekyll-github-metadata


### PR DESCRIPTION
Fixes #6.

/cc @benbalter 