### PR TITLE
Remove build restriction in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,4 @@ rvm:
 script: script/cibuild
 notifications:
   email: false
-branches:
-  only:
-    - master
 sudo: false


### PR DESCRIPTION
There's a restriction in travis that prevents non master branches from triggering a travis build. This causes undo complexity to those that fork the repo and develop a branch to use in the PR.

For instance, I had to create two PRs, one that had the exact change desired and the other that removed the build restriction so I could verify the builds were successful.