### PR TITLE
Bring this gem up-to-date with latest GitHub Pages metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Some `site.github` values can be overridden by environment variables.
 
 Working with `jekyll-github-metadata` and GitHub Enterprise? No sweat. You can configure which API endpoints this plugin will hit to fetch data.
 
+- `SSL` – if "true", sets a number of endpoints to use `https://`, default: `"false"`
 - `OCTOKIT_API_ENDPOINT` – the full hostname and protocol for the api, default: `https://api.github.com`
 - `OCTOKIT_WEB_ENDPOINT` – the full hostname and protocol for the website, default: `https://github.com`
 - `PAGES_PAGES_HOSTNAME` – the full hostname from where GitHub Pages sites are served, default: `github.io`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ gem 'jekyll-github-metadata'
 Then go ahead and run `bundle install`. Once you've done that, add your repo & the gem to your `_config.yml`:
 
 ```yaml
+# or use PAGES_REPO_NWO in the env
 repository: me/super-cool-project
 gems: ['jekyll-github-metadata']
 ```
@@ -49,6 +50,8 @@ $ OCTOKIT_ACCESS_TOKEN=123abc [bundle exec] jekyll serve
 ```
 
 ## Overrides
+
+- `PAGES_REPO_NWO` – overrides `site.repository` as the repo name with owner to fetch (e.g. `jekyll/github-metadata`)
 
 Some `site.github` values can be overridden by environment variables.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ We use [Octokit](https://github.com/octokit/octokit.rb) to make the appropriate 
 $ OCTOKIT_ACCESS_TOKEN=123abc [bundle exec] jekyll serve
 ```
 
+## Overrides
+
+Some `site.github` values can be overridden by environment variables.
+
+- `JEKYLL_BUILD_REVISION` – the `site.github.build_revision`, git SHA of the source site being built. (default: `git rev-parse HEAD`)
+- `PAGES_ENV` – the `site.github.pages_env` (default: `dotcom`)
+- `PAGES_API_URL` – the `site.github.api_url` (default: `https://api/github.com`)
+- `PAGES_HELP_URL` – the `site.github.help_url` (default: `https://help.github.com`)
+- `PAGES_GITHUB_HOSTNAME` – the `site.github.hostname` (default: `https://github.com`)
+- `PAGES_PAGES_HOSTNAME` – the `site.github.pages_hostname` (default: `github.io`)
+
 ## Configuration
 
 Working with `jekyll-github-metadata` and GitHub Enterprise? No sweat. You can configure which API endpoints this plugin will hit to fetch data.
@@ -55,6 +66,7 @@ Working with `jekyll-github-metadata` and GitHub Enterprise? No sweat. You can c
 - `OCTOKIT_API_ENDPOINT` – the full hostname and protocol for the api, default: `https://api.github.com`
 - `OCTOKIT_WEB_ENDPOINT` – the full hostname and protocol for the website, default: `https://github.com`
 - `PAGES_PAGES_HOSTNAME` – the full hostname from where GitHub Pages sites are served, default: `github.io`.
+- `NO_NETRC` – set if you don't want the fallback to `~/.netrc`
 
 ## License
 

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -70,8 +70,12 @@ module Jekyll
 
         # The Juicy Stuff
         register_value('public_repositories',  proc { |c,r| c.list_repos(r.owner, "type" => "public") })
-        register_value('organization_members', proc { |c,r| c.organization_public_members(r.owner) if r.organization_repository? })
-        register_value('build_revision',       proc { `git rev-parse HEAD`.strip })
+        register_value('organization_members', proc { |c,r|
+          c.organization_public_members(r.owner) if r.organization_repository?
+        })
+        register_value('build_revision',       proc {
+          ENV['JEKYLL_BUILD_REVISION'] || `git rev-parse HEAD`.strip
+        })
         register_value('project_title',        proc { |_,r| r.name })
         register_value('project_tagline',      proc { |_,r| r.tagline })
         register_value('owner_name',           proc { |_,r| r.owner })

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -59,6 +59,7 @@ module Jekyll
         register_value('pages_env', proc { Pages.env })
         register_value('pages_hostname', proc { Pages.pages_hostname })
         register_value('api_url', proc { Pages.api_url })
+        register_value('help_url', proc { Pages.help_url })
 
         register_value('versions', proc {
           begin

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -56,6 +56,7 @@ module Jekyll
         # Environment-Specific
         register_value('environment', proc { environment })
         register_value('hostname', proc { Pages.github_hostname })
+        register_value('pages_env', proc { Pages.env })
         register_value('pages_hostname', proc { Pages.pages_hostname })
         register_value('api_url', proc { Pages.api_url })
 

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -1,7 +1,10 @@
+require 'jekyll'
 require 'octokit'
 
 module Jekyll
   module GitHubMetadata
+    NoRepositoryError = Class.new(Jekyll::Errors::FatalException)
+
     autoload :Client,     'jekyll-github-metadata/client'
     autoload :Pages,      'jekyll-github-metadata/pages'
     autoload :Repository, 'jekyll-github-metadata/repository'

--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -5,7 +5,7 @@ module Jekyll
     class GHPMetadataGenerator < Jekyll::Generator
       def generate(site)
         Jekyll.logger.debug "Generator:", "Calling GHPMetadataGenerator"
-        GitHubMetadata.repository ||= GitHubMetadata::Repository.new(nwo(site))
+        GitHubMetadata.repository = GitHubMetadata::Repository.new(nwo(site))
         GitHubMetadata.init!
         site.config['github'] =
           case site.config['github']

--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -5,7 +5,7 @@ module Jekyll
     class GHPMetadataGenerator < Jekyll::Generator
       def generate(site)
         Jekyll.logger.debug "Generator:", "Calling GHPMetadataGenerator"
-        GitHubMetadata.repository = GitHubMetadata::Repository.new(site.config.fetch('repository'))
+        GitHubMetadata.repository ||= GitHubMetadata::Repository.new(nwo(site))
         GitHubMetadata.init!
         site.config['github'] =
           case site.config['github']
@@ -16,6 +16,15 @@ module Jekyll
           else
             site.config['github']
           end
+      end
+
+      def nwo(site)
+        ENV['PAGES_REPO_NWO'] || \
+          site.config['repository'] || \
+          proc {
+            raise GitHubMetadata::NoRepositoryError, "No repo name found. "
+              "Specify using PAGES_REPO_NWO or 'repository' in your configuration."
+          }.call
       end
     end
   end

--- a/lib/jekyll-github-metadata/pages.rb
+++ b/lib/jekyll-github-metadata/pages.rb
@@ -8,7 +8,16 @@ module Jekyll
           'PAGES_HELP_URL'        => 'https://help.github.com'.freeze,
           'PAGES_GITHUB_HOSTNAME' => 'https://github.com'.freeze,
           'PAGES_PAGES_HOSTNAME'  => 'github.io'.freeze,
+          'SSL'                   => 'false'.freeze
         }.freeze
+
+        def ssl?
+          env_var('SSL').eql? 'true'
+        end
+
+        def scheme
+          ssl? ? "https" : "http"
+        end
 
         def env
           env_var 'PAGES_ENV'

--- a/lib/jekyll-github-metadata/pages.rb
+++ b/lib/jekyll-github-metadata/pages.rb
@@ -2,23 +2,39 @@ module Jekyll
   module GitHubMetadata
     class Pages
       class << self
+        DEFAULTS = {
+          'PAGES_ENV'             => 'dotcom'.freeze,
+          'PAGES_API_URL'         => 'https://api.github.com'.freeze,
+          'PAGES_HELP_URL'        => 'https://help.github.com'.freeze,
+          'PAGES_GITHUB_HOSTNAME' => 'https://github.com'.freeze,
+          'PAGES_PAGES_HOSTNAME'  => 'github.io'.freeze,
+        }.freeze
+
         def env
-          ENV.fetch('PAGES_ENV', 'dotcom')
+          env_var 'PAGES_ENV'
         end
 
         def api_url
-          trim_last_slash(ENV['PAGES_API_URL'] || Octokit.api_endpoint || 'https://api.github.com')
+          trim_last_slash env_var('PAGES_API_URL', Octokit.api_endpoint)
+        end
+
+        def help_url
+          trim_last_slash env_var('PAGES_HELP_URL')
         end
 
         def github_hostname
-          trim_last_slash(ENV['PAGES_GITHUB_HOSTNAME'] || Octokit.web_endpoint || 'https://github.com')
+          trim_last_slash env_var('PAGES_GITHUB_HOSTNAME', Octokit.web_endpoint)
         end
 
         def pages_hostname
-          trim_last_slash(ENV.fetch('PAGES_PAGES_HOSTNAME', 'github.io'))
+          trim_last_slash env_var('PAGES_PAGES_HOSTNAME')
         end
 
         private
+        def env_var(key, intermediate_default = nil)
+          !ENV[key].to_s.empty? ? ENV[key] : (intermediate_default || DEFAULTS[key])
+        end
+
         def trim_last_slash(url)
           if url[-1] == "/"
             url[0..-2]

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -101,9 +101,9 @@ module Jekyll
 
       def pages_url
         if cname || primary?
-          "http://#{domain}"
+          "#{Pages.scheme}://#{domain}"
         else
-          File.join("http://#{domain}", name, "")
+          URI.join("#{Pages.scheme}://#{domain}", "#{name}/")
         end
       end
 

--- a/spec/ghp_metadata_generator_spec.rb
+++ b/spec/ghp_metadata_generator_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe(Jekyll::GitHubMetadata::GHPMetadataGenerator) do
+  let(:overrides) { {"repository" => "jekyll/another-repo"} }
+  let(:config) { Jekyll::Configuration::DEFAULTS.merge(overrides) }
+  let(:site) { Jekyll::Site.new config }
+  subject { described_class.new(site.config) }
+
+  context "with no repository set" do
+    before(:each) do
+      site.config.delete('repository')
+      ENV['PAGES_REPO_NWO'] = nil
+    end
+
+    it "raises a NoRepositoryError" do
+      expect(-> {
+        subject.nwo(site)
+      }).to raise_error(Jekyll::GitHubMetadata::NoRepositoryError)
+    end
+  end
+
+  context "with PAGES_REPO_NWO and site.repository set" do
+    before(:each) { ENV['PAGES_REPO_NWO'] = "jekyll/some-repo" }
+
+    it "uses the value from PAGES_REPO_NWO" do
+      expect(subject.nwo(site)).to eql("jekyll/some-repo")
+    end
+  end
+
+  context "with only site.repository set" do
+    before(:each) { ENV['PAGES_REPO_NWO'] = nil }
+
+    it "uses the value from site.repository" do
+      expect(subject.nwo(site)).to eql("jekyll/another-repo")
+    end
+  end
+end

--- a/spec/github_metadata_spec.rb
+++ b/spec/github_metadata_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe(Jekyll::GitHubMetadata) do
   let(:key_value_pair) { %w{some_key some_value} }
 
   before(:each) do
-    described_class.clear_values!
+    described_class.reset!
   end
 
   it 'allows you to register values' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -9,27 +9,42 @@ RSpec.describe("integration into a jekyll site") do
     DEST_DIR.join(*files)
   end
 
-  before(:all) do
+  class ApiStub
+    attr_reader :path, :file
+    attr_accessor :stub
+
+    def initialize(path, file)
+      @path = path
+      @file = file
+    end
+  end
+
+  API_STUBS = {
+    "/users/jekyll/repos?per_page=100&type=public"         => "owner_repos",
+    "/repos/jekyll/github-metadata"                        => "repo",
+    "/orgs/jekyll"                                         => "org",
+    "/orgs/jekyll/public_members?per_page=100"             => "org_members",
+    "/repos/jekyll/github-metadata/pages"                  => "repo_pages",
+    "/repos/jekyll/github-metadata/releases?per_page=100"  => "repo_releases",
+    "/repos/jekyll/github-metadata/contributors?per_page=100" => "repo_contributors"
+  }.map { |path, file| ApiStub.new(path, file) }
+
+  before(:each) do
     # Reset some stuffs
     ENV['NO_NETRC'] = "true"
     ENV['JEYKLL_GITHUB_TOKEN'] = "1234abc"
+    ENV['PAGES_REPO_NWO'] = 'jekyll/github-metadata'
+    Jekyll::GitHubMetadata.reset!
 
     # Stub Requests
-    stub_api "/users/jekyll/repos?per_page=100&type=public",        "owner_repos"
-    stub_api "/repos/jekyll/github-metadata",                       "repo"
-    stub_api "/repos/jekyll/github-metadata/releases?per_page=100", "repo_releases"
-    stub_api "/orgs/jekyll",                                        "org"
-    stub_api "/orgs/jekyll/public_members?per_page=100",            "org_members"
-    stub_api "/repos/jekyll/github-metadata/pages",                 "repo_pages"
-    stub_api "/repos/jekyll/github-metadata/contributors?per_page=100", "repo_contributors"
+    API_STUBS.each { |stub| stub.stub = stub_api(stub.path, stub.file) }
 
     # Run Jekyll
     Jekyll.logger.log_level = :error
     Jekyll::Commands::Build.process({
       "source" => SOURCE_DIR.to_s,
       "destination" => DEST_DIR.to_s,
-      "gems" => %w{jekyll-github-metadata},
-      "repository" => "jekyll/github-metadata"
+      "gems" => %w{jekyll-github-metadata}
     })
   end
   subject { SafeYAML::load(dest_dir("rendered.txt").read) }
@@ -81,6 +96,12 @@ RSpec.describe("integration into a jekyll site") do
       else
         expect(subject[key]).to eql value
       end
+    end
+  end
+
+  it "calls all the stubs" do
+    API_STUBS.each do |stub|
+      expect(stub.stub).to have_been_requested
     end
   end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe("integration into a jekyll site") do
   {
     "environment"          => "development",
     "hostname"             => "https://github.com",
+    "pages_env"            => "dotcom",
     "pages_hostname"       => "github.io",
     "api_url"              => "https://api.github.com",
     "versions"             => proc {

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe("integration into a jekyll site") do
     "hostname"             => "https://github.com",
     "pages_env"            => "dotcom",
     "pages_hostname"       => "github.io",
+    "help_url"             => "https://help.github.com",
     "api_url"              => "https://api.github.com",
     "versions"             => proc {
       begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,13 +38,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
-
   # Limits the available syntax to the non-monkey patched syntax that is recommended.
   # For more details, see:
   #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax


### PR DESCRIPTION
Fixes #28

- `PAGES_REPO_NWO` overrides `site.repository`
- `JEKYLL_BUILD_REVISION` overrides `site.github.build_revision`
- Added 2 missing fields

/cc @jekyll/gh-pages