### PR TITLE
Client: whitelist certain Octokit::Client methods

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe(Jekyll::GitHubMetadata::Client) do
   it "raises an error if an Octokit::Client method is called that's not whitelisted" do
     expect(-> {
       subject.combined_status('jekyll/github-metadata' 'refs/master')
-    }).to raise_error(NoMethodError)
+    }).to raise_error(described_class::InvalidMethodError, "combined_status is not whitelisted on #<Jekyll::GitHubMetadata::Client @client=#<Octokit::Client (authenticated)>>")
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe(Jekyll::GitHubMetadata::Client) do
+  let(:token) { "abc1234" }
+  subject { described_class.new({:access_token => token }) }
+
+  it "whitelists certain api calls" do
+    described_class::API_CALLS.each do |method_name|
+      expect(subject).to respond_to(method_name.to_sym)
+    end
+  end
+
+  it "raises an error if an Octokit::Client method is called that's not whitelisted" do
+    expect(-> {
+      subject.combined_status('jekyll/github-metadata' 'refs/master')
+    }).to raise_error(NoMethodError)
+  end
+end


### PR DESCRIPTION
Instead of responding to _every_ client call, whitelist only a few.

/cc @jekyll/gh-pages