### PR TITLE
All values should have a repository field

### DIFF
--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -73,10 +73,8 @@ module Jekyll
         })
 
         # The Juicy Stuff
-        register_value('public_repositories',  proc { |c,r| c.list_repos(r.owner, "type" => "public") })
-        register_value('organization_members', proc { |c,r|
-          c.organization_public_members(r.owner) if r.organization_repository?
-        })
+        register_value('public_repositories',  proc { |_,r| r.owner_public_repositories })
+        register_value('organization_members', proc { |_,r| r.organization_public_members })
         register_value('build_revision',       proc {
           ENV['JEKYLL_BUILD_REVISION'] || `git rev-parse HEAD`.strip
         })
@@ -99,8 +97,8 @@ module Jekyll
         register_value('is_project_page',      proc { |_,r| r.project_page? })
         register_value('show_downloads',       proc { |_,r| r.show_downloads? })
         register_value('url',                  proc { |_,r| r.pages_url })
-        register_value('contributors',         proc { |c,r| c.contributors(r.nwo) })
-        register_value('releases',             proc { |c,r| c.releases(r.nwo) })
+        register_value('contributors',         proc { |_,r| r.contributors })
+        register_value('releases',             proc { |_,r| r.releases })
 
         values
       end

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -8,15 +8,6 @@ module Jekyll
         @name  = nwo.split("/").last
       end
 
-      def organization_repository?
-        return @is_organization_repository if self.class.const_defined?(@is_organization_repository)
-        @is_organization_repository = !!Value.new(proc { |c| c.organization(owner) }).render
-      end
-      
-      def owner_public_repositories
-        @owner_public_repositories ||= Value.new(proc { |c| c.list_repos(owner, "type" => "public") }).render
-      end
-
       def git_ref
         user_page? ? 'master' : 'gh-pages'
       end
@@ -71,6 +62,32 @@ module Jekyll
 
       def show_downloads?
         !!repo_info["has_downloads"]
+      end
+      
+      def organization_repository?
+        return @is_organization_repository if self.class.const_defined?(@is_organization_repository)
+        @is_organization_repository = !!Value.new(proc { |c| c.organization(owner) }).render
+      end
+      
+      def owner_public_repositories
+        @owner_public_repositories ||= Value.new(proc { |c| c.list_repos(owner, "type" => "public") }).render
+      end
+      
+      def organization_public_members
+        return @organization_public_members if self.class.const_defined?(@organization_public_members)
+        @organization_public_members = Value.new(proc { |c|
+          c.organization_public_members(r.owner) if r.organization_repository?
+        }).render
+      end
+      
+      def contributors
+        return @contributors if self.class.const_defined?(@contributors)
+        @contributors = Value.new(proc { |c| c.contributors(r.nwo) }).render
+      end
+      
+      def releases
+        return @releases if self.class.const_defined?(@releases)
+        @releases = Value.new(proc { |c| c.releases(r.nwo) }).render
       end
 
       def user_page?

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -9,7 +9,12 @@ module Jekyll
       end
 
       def organization_repository?
-        !!Value.new(proc { |c| c.organization(owner) }).render
+        return @is_organization_repository if self.class.const_defined?(@is_organization_repository)
+        @is_organization_repository = !!Value.new(proc { |c| c.organization(owner) }).render
+      end
+      
+      def owner_public_repositories
+        @owner_public_repositories ||= Value.new(proc { |c| c.list_repos(owner, "type" => "public") }).render
       end
 
       def git_ref


### PR DESCRIPTION
This moves any fields which are purely client-generated into memoized fields on `Repository`.

