### PR TITLE
Properly determine project page domain by breaking the cache on different args

### DIFF
--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -1,5 +1,4 @@
 require 'octokit'
-require 'digest'
 
 module Jekyll
   unless const_defined? :Errors

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -1,4 +1,5 @@
 require 'octokit'
+require 'digest'
 
 module Jekyll
   unless const_defined? :Errors

--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -45,10 +45,9 @@ module Jekyll
       def method_missing(method_name, *args, &block)
         method = method_name.to_s
         if accepts_client_method?(method_name)
-          instance_var_name = method.sub('?', '_')
+          key = cache_key(method_name, args)
           Jekyll.logger.debug "GitHub Metadata:", "Calling @client.#{method}(#{args.map(&:inspect).join(", ")})"
-          instance_variable_get(:"@#{instance_var_name}") ||
-            instance_variable_set(:"@#{instance_var_name}", save_from_errors { @client.public_send(method_name, *args, &block) })
+          cache[key] || cache[key] = save_from_errors { @client.public_send(method_name, *args, &block) }
         elsif @client.respond_to?(method_name)
           raise InvalidMethodError, "#{method_name} is not whitelisted on #{inspect}"
         else
@@ -93,6 +92,14 @@ module Jekyll
             " Some fields may be missing or have incorrect data."
           {}.freeze
         end
+      end
+
+      def cache_key(method, *args)
+        Digest::SHA1.hexdigest(method.to_s + args.join(", "))
+      end
+
+      def cache
+        @cache ||= {}
       end
     end
   end

--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -47,7 +47,7 @@ module Jekyll
         if accepts_client_method?(method_name)
           key = cache_key(method_name, args)
           Jekyll.logger.debug "GitHub Metadata:", "Calling @client.#{method}(#{args.map(&:inspect).join(", ")})"
-          cache[key] || cache[key] = save_from_errors { @client.public_send(method_name, *args, &block) }
+          cache[key] ||= save_from_errors { @client.public_send(method_name, *args, &block) }
         elsif @client.respond_to?(method_name)
           raise InvalidMethodError, "#{method_name} is not whitelisted on #{inspect}"
         else

--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -1,3 +1,5 @@
+require 'digest'
+
 module Jekyll
   module GitHubMetadata
     class Client

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -21,14 +21,17 @@ RSpec.describe("integration into a jekyll site") do
   end
 
   API_STUBS = {
-    "/users/jekyll/repos?per_page=100&type=public"         => "owner_repos",
-    "/repos/jekyll/github-metadata"                        => "repo",
-    "/orgs/jekyll"                                         => "org",
-    "/orgs/jekyll/public_members?per_page=100"             => "org_members",
-    "/repos/jekyll/github-metadata/pages"                  => "repo_pages",
-    "/repos/jekyll/github-metadata/releases?per_page=100"  => "repo_releases",
+    "/users/jekyll/repos?per_page=100&type=public"            => "owner_repos",
+    "/repos/jekyll/github-metadata"                           => "repo",
+    "/orgs/jekyll"                                            => "org",
+    "/orgs/jekyll/public_members?per_page=100"                => "org_members",
+    "/repos/jekyll/github-metadata/pages"                     => "repo_pages",
+    "/repos/jekyll/github-metadata/releases?per_page=100"     => "repo_releases",
     "/repos/jekyll/github-metadata/contributors?per_page=100" => "repo_contributors",
-    "/repos/jekyll/jekyll.github.io"                          => "not_found"
+    "/repos/jekyll/jekyll.github.io"                          => "not_found",
+    "/repos/jekyll/jekyll.github.com"                         => "repo",
+    "/repos/jekyll/jekyll.github.com/pages"                   => "repo_pages",
+    "/repos/jekyll/jekyll.github.io/pages"                    => "repo_pages"
   }.map { |path, file| ApiStub.new(path, file) }
 
   before(:each) do


### PR DESCRIPTION
Right now, if the client makes a call to the same endpoint, but for two different domains (or the same endpoint, but with different arguments), it will return the first, cached result.

That's because the client caches on the method name, irregardless of arguments.

This PR creates a cache hash (rather than using instance variables), and computes a unique key, using SHA1, which I guessed was the cheapest way to generate a unique, consistent hash from the method name + args (knowing that the args may be long).

Thoughts on this approach?

Fixes https://github.com/jekyll/github-metadata/issues/39