### PR TITLE
make empty string fallback for missing git remote

### DIFF
--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -31,7 +31,7 @@ module Jekyll
       def git_remote_url
         `git remote --verbose`.split("\n").grep(%r{\Aorigin\t}).map do |remote|
           remote.sub(/\Aorigin\t(.*) \([a-z]+\)/, "\\1")
-        end.uniq.first
+        end.uniq.first || ""
       end
 
       def git_nwo


### PR DESCRIPTION
Hi,
see https://github.com/jekyll/jekyll/issues/4748 for more information about the issue.

**Before**
![bildschirmfoto 2016-04-05 um 21 05 23](https://cloud.githubusercontent.com/assets/570608/14294589/305b827e-fb72-11e5-920e-7ca2e402f52f.png)

**After**
![bildschirmfoto 2016-04-05 um 21 05 36](https://cloud.githubusercontent.com/assets/570608/14294598/3aaaf642-fb72-11e5-8126-3abc1a1b1277.png)
