### PR TITLE
remove unneeded param `type`

### DIFF
--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -69,7 +69,7 @@ module Jekyll
       end
 
       def owner_public_repositories
-        memoize_value :@owner_public_repositories, Value.new(proc { |c| c.list_repos(owner, "type" => "public") })
+        memoize_value :@owner_public_repositories, Value.new(proc { |c| c.list_repos(owner) })
       end
 
       def organization_public_members

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe("integration into a jekyll site") do
   end
 
   API_STUBS = {
-    "/users/jekyll/repos?per_page=100&type=public"            => "owner_repos",
+    "/users/jekyll/repos?per_page=100"                        => "owner_repos",
     "/repos/jekyll/github-metadata"                           => "repo",
     "/orgs/jekyll"                                            => "org",
     "/orgs/jekyll/public_members?per_page=100"                => "org_members",


### PR DESCRIPTION
Hi,
`GET /users/:username/repos` only returns public repos by default and `public` isn't even one of the available options for the `type` param.
See https://developer.github.com/v3/repos/#list-user-repositories for more
information.