### PR TITLE
Only determine repo when data is requested using a Drop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       env: GITHUB_PAGES=80
 env:
   matrix:
-    - JEKYLL_VERSION=3.0
+    - JEKYLL_VERSION=3.1
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ rvm:
 matrix:
   include:
     - rvm: 2.1.7
-      env: JEKYLL_VERSION=2.5
-    - rvm: 2.1.7
-      env: GITHUB_PAGES=45
+      env: GITHUB_PAGES=80
 env:
   matrix:
     - JEKYLL_VERSION=3.0

--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "octokit", "~> 4.0"
+  spec.add_runtime_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.1"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "netrc"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 2.0"
   spec.add_development_dependency "github-pages", ENV["GITHUB_PAGES"] if ENV["GITHUB_PAGES"]
 end

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -20,12 +20,17 @@ module Jekyll
     NoRepositoryError = Class.new(Jekyll::Errors::FatalException)
 
     autoload :Client,           'jekyll-github-metadata/client'
+    autoload :MetadataDrop,     'jekyll-github-metadata/metadata_drop'
     autoload :Pages,            'jekyll-github-metadata/pages'
     autoload :Repository,       'jekyll-github-metadata/repository'
     autoload :RepositoryCompat, 'jekyll-github-metadata/repository_compat'
     autoload :Sanitizer,        'jekyll-github-metadata/sanitizer'
     autoload :Value,            'jekyll-github-metadata/value'
     autoload :VERSION,          'jekyll-github-metadata/version'
+
+    if Jekyll.const_defined? :Site
+      require_relative 'jekyll-github-metadata/ghp_metadata_generator'
+    end
 
     class << self
       attr_accessor :repository
@@ -54,86 +59,6 @@ module Jekyll
       def client
         @client ||= Client.new
       end
-
-      def values
-        @values ||= Hash.new
-      end
-      alias_method :to_h, :values
-      alias_method :to_liquid, :to_h
-
-      def clear_values!
-        @values = Hash.new
-      end
-
-      def reset!
-        clear_values!
-        @client = nil
-        @repository = nil
-      end
-
-      def [](key)
-        values[key.to_s]
-      end
-
-      def register_value(key, value)
-        values[key.to_s] = Value.new(key.to_s, value)
-      end
-
-      # Reset our values hash.
-      def init!
-        clear_values!
-
-        # Environment-Specific
-        register_value('environment', proc { Pages.env })
-        register_value('hostname', proc { Pages.github_hostname })
-        register_value('pages_env', proc { Pages.env })
-        register_value('pages_hostname', proc { Pages.pages_hostname })
-        register_value('api_url', proc { Pages.api_url })
-        register_value('help_url', proc { Pages.help_url })
-
-        register_value('versions', proc {
-          begin
-            require 'github-pages'
-            GitHubPages.versions
-          rescue LoadError; Hash.new end
-        })
-
-        # The Juicy Stuff
-        register_value('public_repositories',  proc { |_,r| r.owner_public_repositories })
-        register_value('organization_members', proc { |_,r| r.organization_public_members })
-        register_value('build_revision',       proc {
-          ENV['JEKYLL_BUILD_REVISION'] || `git rev-parse HEAD`.strip
-        })
-        register_value('project_title',        proc { |_,r| r.name })
-        register_value('project_tagline',      proc { |_,r| r.tagline })
-        register_value('owner_name',           proc { |_,r| r.owner })
-        register_value('owner_url',            proc { |_,r| r.owner_url })
-        register_value('owner_gravatar_url',   proc { |_,r| r.owner_gravatar_url })
-        register_value('repository_url',       proc { |_,r| r.repository_url })
-        register_value('repository_nwo',       proc { |_,r| r.nwo })
-        register_value('repository_name',      proc { |_,r| r.name})
-        register_value('zip_url',              proc { |_,r| r.zip_url })
-        register_value('tar_url',              proc { |_,r| r.tar_url })
-        register_value('clone_url',            proc { |_,r| r.repo_clone_url })
-        register_value('releases_url',         proc { |_,r| r.releases_url })
-        register_value('issues_url',           proc { |_,r| r.issues_url })
-        register_value('wiki_url',             proc { |_,r| r.wiki_url })
-        register_value('language',             proc { |_,r| r.language })
-        register_value('is_user_page',         proc { |_,r| r.user_page? })
-        register_value('is_project_page',      proc { |_,r| r.project_page? })
-        register_value('show_downloads',       proc { |_,r| r.show_downloads? })
-        register_value('url',                  proc { |_,r| r.html_url })
-        register_value('contributors',         proc { |_,r| r.contributors })
-        register_value('releases',             proc { |_,r| r.releases })
-
-        values
-      end
-
-      if Jekyll.const_defined? :Site
-        require_relative 'jekyll-github-metadata/ghp_metadata_generator'
-      end
     end
-
-    init!
   end
 end

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -59,6 +59,11 @@ module Jekyll
       def client
         @client ||= Client.new
       end
+
+      def reset!
+        @logger = nil
+        @client = nil
+      end
     end
   end
 end

--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -1,74 +1,23 @@
+require 'jekyll'
+
 module Jekyll
   module GitHubMetadata
     class GHPMetadataGenerator < Jekyll::Generator
       safe true
 
       def generate(site)
-        Jekyll::GitHubMetadata.log :debug, "Calling GHPMetadataGenerator"
-        initialize_repo! nwo(site)
-        Jekyll::GitHubMetadata.log :debug, "Generating for #{GitHubMetadata.repository.nwo}"
+        Jekyll::GitHubMetadata.log :debug, "Initializing..."
 
+        drop = MetadataDrop.new(site)
         site.config['github'] =
           case site.config['github']
           when nil
-            GitHubMetadata.to_liquid
-          when Hash
-            Jekyll::Utils.deep_merge_hashes(GitHubMetadata.to_liquid, site.config['github'])
+            MetadataDrop.new(site)
+          when Hash, Liquid::Drop
+            Jekyll::Utils.deep_merge_hashes(MetadataDrop.new(site), site.config['github'])
           else
             site.config['github']
           end
-      end
-
-      private
-
-      def initialize_repo!(repo_nwo)
-        if GitHubMetadata.repository.nil? || GitHubMetadata.repository.nwo != repo_nwo
-          GitHubMetadata.init!
-          GitHubMetadata.repository = GitHubMetadata::Repository.new(repo_nwo)
-        end
-      end
-
-      def git_remote_url
-        `git remote --verbose`.split("\n").grep(%r{\Aorigin\t}).map do |remote|
-          remote.sub(/\Aorigin\t(.*) \([a-z]+\)/, "\\1")
-        end.uniq.first || ""
-      end
-
-      def nwo_from_git_origin_remote
-        return unless Jekyll.env == "development"
-        matches = git_remote_url.match %r{github.com(:|/)([\w-]+)/([\w-]+)}
-        matches[2..3].join("/") if matches
-      end
-
-      def nwo_from_env
-        ENV['PAGES_REPO_NWO']
-      end
-
-      def nwo_from_config(site)
-        repo = site.config['repository']
-        repo if repo && repo.is_a?(String) && repo.include?('/')
-      end
-
-      # Public: fetches the repository name with owner to fetch metadata for.
-      # In order of precedence, this method uses:
-      # 1. the environment variable $PAGES_REPO_NWO
-      # 2. 'repository' variable in the site config
-      # 3. the 'origin' git remote's URL
-      #
-      # site - the Jekyll::Site being processed
-      #
-      # Return the name with owner (e.g. 'parkr/my-repo') or raises an
-      # error if one cannot be found.
-      def nwo(site)
-        nwo_from_env || \
-          nwo_from_config(site) || \
-          nwo_from_git_origin_remote || \
-          proc {
-            raise GitHubMetadata::NoRepositoryError, "No repo name found. " \
-              "Specify using PAGES_REPO_NWO environment variables, " \
-              "'repository' in your configuration, or set up an 'origin' " \
-              "git remote pointing to your github.com repository."
-          }.call
       end
     end
   end

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -1,0 +1,122 @@
+require 'jekyll'
+require 'forwardable'
+
+module Jekyll
+  module GitHubMetadata
+    class MetadataDrop < Jekyll::Drops::Drop
+      extend Forwardable
+
+      def initialize(site)
+        @site = site
+        super(nil)
+      end
+
+      def keys
+        super.sort
+      end
+
+      def_delegator :"Jekyll::GitHubMetadata::Pages", :env, :environment
+      def_delegator :"Jekyll::GitHubMetadata::Pages", :env, :pages_env
+      def_delegator :"Jekyll::GitHubMetadata::Pages", :github_hostname, :hostname
+      def_delegator :"Jekyll::GitHubMetadata::Pages", :pages_hostname, :pages_hostname
+      def_delegator :"Jekyll::GitHubMetadata::Pages", :api_url, :api_url
+      def_delegator :"Jekyll::GitHubMetadata::Pages", :help_url, :help_url
+
+      def versions
+        @versions ||= begin
+          require 'github-pages'
+          GitHubPages.versions
+        rescue LoadError
+          {}
+        end
+      end
+
+      def build_revision
+        @build_revision ||= (
+          ENV['JEKYLL_BUILD_REVISION'] || `git rev-parse HEAD`.strip
+        )
+      end
+
+      def_delegator :repository, :owner_public_repositories,   :public_repositories
+      def_delegator :repository, :organization_public_members, :organization_members
+      def_delegator :repository, :name,                        :project_title
+      def_delegator :repository, :tagline,                     :project_tagline
+      def_delegator :repository, :owner,                       :owner_name
+      def_delegator :repository, :owner_url,                   :owner_url
+      def_delegator :repository, :owner_gravatar_url,          :owner_gravatar_url
+      def_delegator :repository, :repository_url,              :repository_url
+      def_delegator :repository, :nwo,                         :repository_nwo
+      def_delegator :repository, :name,                        :repository_name
+      def_delegator :repository, :zip_url,                     :zip_url
+      def_delegator :repository, :tar_url,                     :tar_url
+      def_delegator :repository, :repo_clone_url,              :clone_url
+      def_delegator :repository, :releases_url,                :releases_url
+      def_delegator :repository, :issues_url,                  :issues_url
+      def_delegator :repository, :wiki_url,                    :wiki_url
+      def_delegator :repository, :language,                    :language
+      def_delegator :repository, :user_page?,                  :is_user_page
+      def_delegator :repository, :project_page?,               :is_project_page
+      def_delegator :repository, :show_downloads?,             :show_downloads
+      def_delegator :repository, :html_url,                    :url
+      def_delegator :repository, :contributors,                :contributors
+      def_delegator :repository, :releases,                    :releases
+
+      private
+      attr_reader :site
+
+      def repository
+        @repository ||= GitHubMetadata::Repository.new(nwo(site)).tap do |repo|
+          Jekyll::GitHubMetadata.log :debug, "Generating for #{repo.nwo}"
+        end
+      end
+
+      def git_remote_url
+        `git remote --verbose`.split("\n").grep(%r{\Aorigin\t}).map do |remote|
+          remote.sub(/\Aorigin\t(.*) \([a-z]+\)/, "\\1")
+        end.uniq.first || ""
+      end
+
+      def nwo_from_git_origin_remote
+        return unless Jekyll.env == "development"
+        matches = git_remote_url.match %r{github.com(:|/)([\w-]+)/([\w-]+)}
+        matches[2..3].join("/") if matches
+      end
+
+      def nwo_from_env
+        ENV['PAGES_REPO_NWO']
+      end
+
+      def nwo_from_config(site)
+        repo = site.config['repository']
+        repo if repo && repo.is_a?(String) && repo.include?('/')
+      end
+
+      # Public: fetches the repository name with owner to fetch metadata for.
+      # In order of precedence, this method uses:
+      # 1. the environment variable $PAGES_REPO_NWO
+      # 2. 'repository' variable in the site config
+      # 3. the 'origin' git remote's URL
+      #
+      # site - the Jekyll::Site being processed
+      #
+      # Return the name with owner (e.g. 'parkr/my-repo') or raises an
+      # error if one cannot be found.
+      def nwo(site)
+        nwo_from_env || \
+          nwo_from_config(site) || \
+          nwo_from_git_origin_remote || \
+          proc {
+            raise GitHubMetadata::NoRepositoryError, "No repo name found. " \
+              "Specify using PAGES_REPO_NWO environment variables, " \
+              "'repository' in your configuration, or set up an 'origin' " \
+              "git remote pointing to your github.com repository."
+          }.call
+      end
+
+      # Nothing to see here.
+      def fallback_data
+        @fallback_data ||= {}
+      end
+    end
+  end
+end

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -6,6 +6,8 @@ module Jekyll
     class MetadataDrop < Jekyll::Drops::Drop
       extend Forwardable
 
+      mutable true
+
       def initialize(site)
         @site = site
         super(nil)

--- a/script/test
+++ b/script/test
@@ -1,2 +1,3 @@
 #!/bin/bash
+echo Testing with $(bundle exec jekyll --version)
 bundle exec rspec --color --require spec_helper $@

--- a/spec/ghp_metadata_generator_spec.rb
+++ b/spec/ghp_metadata_generator_spec.rb
@@ -3,61 +3,9 @@ require 'jekyll'
 require 'jekyll-github-metadata/ghp_metadata_generator'
 
 RSpec.describe(Jekyll::GitHubMetadata::GHPMetadataGenerator) do
-  let(:overrides) { {"repository" => "jekyll/another-repo"} }
-  let(:config) { Jekyll::Configuration::DEFAULTS.merge(overrides) }
-  let(:site) { Jekyll::Site.new config }
   subject { described_class.new }
 
   it "is safe" do
     expect(described_class.safe).to be(true)
-  end
-
-  context "with no repository set" do
-    before(:each) do
-      site.config.delete('repository')
-      ENV['PAGES_REPO_NWO'] = nil
-    end
-
-    context "without a git nwo" do
-      it "raises a NoRepositoryError" do
-        allow(subject).to receive(:git_remote_url).and_return("")
-        expect(-> {
-          subject.send(:nwo, site)
-        }).to raise_error(Jekyll::GitHubMetadata::NoRepositoryError)
-      end
-    end
-
-    it "retrieves the git remote" do
-      allow(subject).to receive(:git_remote_url).and_call_original
-      expect(subject.send(:git_remote_url)).to include("jekyll/github-metadata")
-    end
-
-    {
-      https: "https://github.com/foo/bar",
-      ssh:   "git@github.com:foo/bar.git"
-    }.each do |type, url|
-      context "with a #{type} git URL" do
-        it "parses the name with owner from the git URL" do
-          allow(subject).to receive(:git_remote_url).and_return(url)
-          expect(subject.send(:nwo, site)).to eql("foo/bar")
-        end
-      end
-    end
-  end
-
-  context "with PAGES_REPO_NWO and site.repository set" do
-    before(:each) { ENV['PAGES_REPO_NWO'] = "jekyll/some-repo" }
-
-    it "uses the value from PAGES_REPO_NWO" do
-      expect(subject.send(:nwo, site)).to eql("jekyll/some-repo")
-    end
-  end
-
-  context "with only site.repository set" do
-    before(:each) { ENV['PAGES_REPO_NWO'] = nil }
-
-    it "uses the value from site.repository" do
-      expect(subject.send(:nwo, site)).to eql("jekyll/another-repo")
-    end
   end
 end

--- a/spec/github_metadata_spec.rb
+++ b/spec/github_metadata_spec.rb
@@ -3,29 +3,6 @@ require 'spec_helper'
 RSpec.describe(Jekyll::GitHubMetadata) do
   let(:key_value_pair) { %w{some_key some_value} }
 
-  before(:each) do
-    described_class.reset!
-  end
-
-  it 'allows you to register values' do
-    expect(described_class.register_value(*key_value_pair)).not_to be_nil
-  end
-
-  it 'knows how to turn into Liquid' do
-    expect(described_class).to respond_to(:to_liquid)
-    expect(described_class.to_liquid).to be_a(Hash)
-  end
-
-  it 'has a hash representation' do
-    expect(described_class).to respond_to(:to_h)
-    expect(described_class.to_h).to be_a(Hash)
-  end
-
-  it 'stores the key-value pairs in a values hash' do
-    described_class.register_value(*key_value_pair)
-    expect(described_class['some_key'].to_s).to eql('some_value')
-  end
-
   it 'has a global GitHub API client' do
     expect(described_class.client).to be_a(Jekyll::GitHubMetadata::Client)
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe("integration into a jekyll site") do
     ENV['JEKYLL_GITHUB_TOKEN'] = "1234abc"
     ENV['PAGES_REPO_NWO'] = "jekyll/github-metadata"
     ENV['PAGES_ENV'] = "dotcom"
-    Jekyll::GitHubMetadata.reset!
 
     # Stub Requests
     API_STUBS.each { |stub| stub.stub = stub_api(stub.path, stub.file) }

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
+  let(:overrides) { {"repository" => "jekyll/another-repo"} }
+  let(:config) { Jekyll::Configuration::DEFAULTS.merge(overrides) }
+  let(:site) { Jekyll::Site.new config }
+  subject { described_class.new(site) }
+
+  context "with no repository set" do
+    before(:each) do
+      site.config.delete('repository')
+      ENV['PAGES_REPO_NWO'] = nil
+    end
+
+    context "without a git nwo" do
+      it "raises a NoRepositoryError" do
+        allow(subject).to receive(:git_remote_url).and_return("")
+        expect(-> {
+          subject.send(:nwo, site)
+        }).to raise_error(Jekyll::GitHubMetadata::NoRepositoryError)
+      end
+    end
+
+    it "retrieves the git remote" do
+      allow(subject).to receive(:git_remote_url).and_call_original
+      expect(subject.send(:git_remote_url)).to include("jekyll/github-metadata")
+    end
+
+    {
+      https: "https://github.com/foo/bar",
+      ssh:   "git@github.com:foo/bar.git"
+    }.each do |type, url|
+      context "with a #{type} git URL" do
+        it "parses the name with owner from the git URL" do
+          allow(subject).to receive(:git_remote_url).and_return(url)
+          expect(subject.send(:nwo, site)).to eql("foo/bar")
+        end
+      end
+    end
+  end
+
+  context "with PAGES_REPO_NWO and site.repository set" do
+    before(:each) { ENV['PAGES_REPO_NWO'] = "jekyll/some-repo" }
+
+    it "uses the value from PAGES_REPO_NWO" do
+      expect(subject.send(:nwo, site)).to eql("jekyll/some-repo")
+    end
+  end
+
+  context "with only site.repository set" do
+    before(:each) { ENV['PAGES_REPO_NWO'] = nil }
+
+    it "uses the value from site.repository" do
+      expect(subject.send(:nwo, site)).to eql("jekyll/another-repo")
+    end
+  end
+end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
   let(:repo) { described_class.new(nwo) }
   before(:each) do
     ENV['JEKYLL_GITHUB_TOKEN'] = "allthespecs"
-    Jekyll::GitHubMetadata.reset!
     stub.stub = stub_api(stub.path, stub.file, stub.request_headers)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,7 +144,8 @@ RSpec.configure do |config|
   WebMock.disable_net_connect!
   config.include EnvHelper
 
-  Jekyll::GitHubMetadata.logger = Logger.new(StringIO.new) unless ENV["DEBUG"]
-
-  config.before(:each) { Jekyll::GitHubMetadata.init! }
+  config.before(:each) do
+    Jekyll::GitHubMetadata.reset!
+    Jekyll::GitHubMetadata.logger = Logger.new(StringIO.new) unless ENV["DEBUG"]
+  end
 end


### PR DESCRIPTION
This PR uses a `Jekyll::Drops::Drop` to generate all of the repository information **only when requested**.

For example:

### No `site.github` usage:

```text
~/jekyll/jekyll/site#master$ PAGES_PREVIEW_HTML_URL=true JEKYLL_GITHUB_TOKEN=$(cat ~/.token) be jekyll serve --verbose --trace | grep GitHub
   GitHub Metadata: Initializing...
```

No calls.

### Using `jekyll-sitemap` or `jekyll-feed` which only uses `site.github.url`:

```text
~/jekyll/jekyll/site#master$ PAGES_PREVIEW_HTML_URL=true JEKYLL_GITHUB_TOKEN=$(cat ~/.token) be jekyll serve --verbose --trace | grep GitHub
   GitHub Metadata: Initializing...
   GitHub Metadata: Generating for jekyll/jekyll
   GitHub Metadata: Calling @client.pages("jekyll/jekyll", {:accept=>"application/vnd.github.mister-fantastic-preview+json"})
```

### Printing out all values via something like `{{ site | jsonify }}`:

```text
   GitHub Metadata: Initializing...
   GitHub Metadata: Generating for jekyll/jekyll
   GitHub Metadata: Calling @client.pages("jekyll/jekyll", {:accept=>"application/vnd.github.mister-fantastic-preview+json"})
   GitHub Metadata: Calling @client.contributors("jekyll/jekyll")
   GitHub Metadata: Calling @client.repository("jekyll/jekyll")
   GitHub Metadata: Calling @client.organization("jekyll")
   GitHub Metadata: Calling @client.organization_public_members("jekyll")
   GitHub Metadata: Calling @client.list_repos("jekyll", {"type"=>"public"})
   GitHub Metadata: Calling @client.releases("jekyll/jekyll")
```

Fixes #52.