### PR TITLE
Handle dots in repository names when parsing from Git remote output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 matrix:
   include:
     - rvm: 2.1.7
-      env: GITHUB_PAGES=80
+      env: GITHUB_PAGES=83
 env:
   matrix:
     - JEKYLL_VERSION=3.1

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -76,16 +76,20 @@ module Jekyll
         ENV["PATH"].to_s.split(File::PATH_SEPARATOR).map { |path| File.join(path, "git") }.find { |path| File.exist?(path) }
       end
 
+      def git_remotes
+        return [] if git_exe_path.nil?
+        `#{git_exe_path} remote --verbose`.to_s.strip.split("\n")
+      end
+
       def git_remote_url
-        return "" if git_exe_path.nil?
-        `#{git_exe_path} remote --verbose`.split("\n").grep(%r{\Aorigin\t}).map do |remote|
+        git_remotes.grep(%r{\Aorigin\t}).map do |remote|
           remote.sub(/\Aorigin\t(.*) \([a-z]+\)/, "\\1")
         end.uniq.first || ""
       end
 
       def nwo_from_git_origin_remote
         return unless Jekyll.env == "development"
-        matches = git_remote_url.match %r{github.com(:|/)([\w-]+)/([\w-]+)}
+        matches = git_remote_url.chomp(".git").match %r{github.com(:|/)([\w-]+)/([\w\.-]+)}
         matches[2..3].join("/") if matches
       end
 

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
   end
 
   context "when determining the nwo via git" do
+    it "handles periods in repo names" do
+      allow(subject).to receive(:git_remote_url).and_return <<-EOS
+origin  https://github.com/afeld/hackerhours.org.git (fetch)
+origin  https://github.com/afeld/hackerhours.org.git (push)
+EOS
+      expect(subject.send(:nwo_from_git_origin_remote)).to include("afeld/hackerhours.org")
+    end
+
     context "when git doesn't exist" do
       before(:each) { @old_path = ENV.delete("PATH").to_s.split(File::PATH_SEPARATOR) }
       after(:each)  { ENV["PATH"] = @old_path.join(File::PATH_SEPARATOR) }


### PR DESCRIPTION
Fixes #62 for @afeld. 😄 

/cc @jekyll/gh-pages 