### PR TITLE
Remove trailing slash from html_url if present

### DIFF
--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -144,7 +144,7 @@ module Jekyll
       end
 
       def html_url
-        @html_url ||= (repo_pages_info["html_url"].chomp("/") || repo_compat.pages_url)
+        @html_url ||= (repo_pages_info["html_url"] || repo_compat.pages_url).chomp("/")
       end
 
       def uri

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -144,7 +144,7 @@ module Jekyll
       end
 
       def html_url
-        @html_url ||= (repo_pages_info["html_url"] || repo_compat.pages_url)
+        @html_url ||= (repo_pages_info["html_url"].chomp("/") || repo_compat.pages_url)
       end
 
       def uri

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
 
     it "uses the html_url" do
       expect(repo.html_url).to eql("http://jekyllrb.com")
-      expect(repo.repo_pages_info["html_url"]).to eql(repo.html_url)
+      expect(repo.repo_pages_info["html_url"]).to eql("#{repo.html_url}/")
     end
 
     it "sees the preview env" do

--- a/spec/webmock/api_get_jekyll_repo_pages.json
+++ b/spec/webmock/api_get_jekyll_repo_pages.json
@@ -3,5 +3,5 @@
   "status": "built",
   "cname": "jekyllrb.com",
   "custom_404": false,
-  "html_url": "http://jekyllrb.com"
+  "html_url": "http://jekyllrb.com/"
 }


### PR DESCRIPTION
For consistency, the `html_url` field of the pages preview API will begin returning URLs with trailing slashes in all cases. Because many sites hardcode things like `{{ page.url | prepend: site.github.url }}`, we need to maintain backwards compatibility, and have `site.github.url` continue to *not* have a trailing slash.

This PR simply strips the trailing slash from the calculated URL or API response, if it's present, so that we never have a trailing slash. Ever.