### PR TITLE
Expose mention URL base

### DIFF
--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -23,6 +23,7 @@ module Jekyll
       def_delegator :"Jekyll::GitHubMetadata::Pages", :pages_hostname, :pages_hostname
       def_delegator :"Jekyll::GitHubMetadata::Pages", :api_url, :api_url
       def_delegator :"Jekyll::GitHubMetadata::Pages", :help_url, :help_url
+      def_delegator :"Jekyll::GitHubMetadata::Pages", :mention_url_base
 
       def versions
         @versions ||= begin

--- a/lib/jekyll-github-metadata/pages.rb
+++ b/lib/jekyll-github-metadata/pages.rb
@@ -52,7 +52,8 @@ module Jekyll
             "#{scheme}://#{github_hostname}"
           end
         end
-
+        alias_method :mention_url_base, :github_url
+        
         def api_url
           trim_last_slash env_var('PAGES_API_URL', ENV['API_URL'])
         end

--- a/spec/pages_spec.rb
+++ b/spec/pages_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe(Jekyll::GitHubMetadata::Pages) do
     it "looks for the domain specified" do
       with_env("GITHUB_HOSTNAME", ghe_domain) do
         expect(described_class.github_url).to eql("http://#{ghe_domain}")
+        expect(described_class.mention_url_base).to eql("http://#{ghe_domain}")
         expect(described_class.github_hostname).to eql ghe_domain
       end
     end


### PR DESCRIPTION
Part of the fix for https://github.com/jekyll/jekyll-mentions/issues/34, this pull request exposes `site.github.mention_url_base`, which will be the hostname + scheme, to allow Jekyll mentions to default to the proper hostname in Enterprise.