### PR TITLE
Dont try to build with the latest released pages gem to avoid conflicts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
 env:
   matrix:
     - JEKYLL_VERSION=3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,20 @@
 sudo: false
 language: ruby
 rvm:
-- 2.1.7
-- 2.2
-- 2.3.0
-matrix:
-  include:
-    - rvm: 2.1.7
-      env: GITHUB_PAGES=83
+  - 2.1
+  - 2.2
+  - 2.3
 env:
   matrix:
     - JEKYLL_VERSION=3.1
+    - JEKYLL_VERSION=3.2
 branches:
   only:
     - master
 install:
-- travis_retry script/bootstrap
+  - travis_retry script/bootstrap
 script: script/cibuild
+cache: bundler
 notifications:
   irc:
     on_success: change

--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "netrc"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "github-pages", ENV["GITHUB_PAGES"] if ENV["GITHUB_PAGES"]
 end


### PR DESCRIPTION
Tests on master are currently broken, and given our current set up, will always be broken when this repo has a different version number than the version used in the last release of GitHub Pages.

This PR updates the travis config to not try to build against the latest Pages gem version (which is built as part of CI upstream now). 