### PR TITLE
Spike out setting site.url and site.baseurl

### DIFF
--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -5,18 +5,31 @@ module Jekyll
     class GHPMetadataGenerator < Jekyll::Generator
       safe true
 
+      attr_reader :site
+
       def generate(site)
         Jekyll::GitHubMetadata.log :debug, "Initializing..."
+        @site = site
+        site.config["github"]  = github_namespace
+        site.config["url"]     = drop.url if site.config["url"].nil?
+        site.config["baseurl"] = drop.baseurl if site.config["baseurl"].nil?
+      end
 
-        site.config["github"] =
-          case site.config["github"]
-          when nil
-            MetadataDrop.new(site)
-          when Hash, Liquid::Drop
-            Jekyll::Utils.deep_merge_hashes(MetadataDrop.new(site), site.config["github"])
-          else
-            site.config["github"]
-          end
+      private
+
+      def github_namespace
+        case site.config["github"]
+        when nil
+          drop
+        when Hash, Liquid::Drop
+          Jekyll::Utils.deep_merge_hashes(drop, site.config["github"])
+        else
+          site.config["github"]
+        end
+      end
+
+      def drop
+        @drop ||= MetadataDrop.new(site)
       end
     end
   end

--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -11,8 +11,14 @@ module Jekyll
         Jekyll::GitHubMetadata.log :debug, "Initializing..."
         @site = site
         site.config["github"] = github_namespace
-        site.config["url"] ||= drop.url
-        site.config["baseurl"] ||= drop.baseurl
+
+        # Set `site.url` and `site.baseurl` if unset and in production mode.
+        if Jekyll.env == "production"
+          site.config["url"] ||= drop.url
+          site.config["baseurl"] = drop.baseurl if site.config["baseurl"].to_s.empty?
+        end
+
+        @site = nil
       end
 
       private

--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -10,9 +10,9 @@ module Jekyll
       def generate(site)
         Jekyll::GitHubMetadata.log :debug, "Initializing..."
         @site = site
-        site.config["github"]  = github_namespace
-        site.config["url"]     = drop.url if site.config["url"].nil?
-        site.config["baseurl"] = drop.baseurl if site.config["baseurl"].nil?
+        site.config["github"] = github_namespace
+        site.config["url"] ||= drop.url
+        site.config["baseurl"] ||= drop.baseurl
       end
 
       private

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -60,6 +60,7 @@ module Jekyll
       def_delegator :repository, :project_page?,               :is_project_page
       def_delegator :repository, :show_downloads?,             :show_downloads
       def_delegator :repository, :html_url,                    :url
+      def_delegator :repository, :baseurl,                     :baseurl
       def_delegator :repository, :contributors,                :contributors
       def_delegator :repository, :releases,                    :releases
 

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -159,6 +159,10 @@ module Jekyll
         uri.scheme
       end
 
+      def baseurl
+        uri.path
+      end
+
       private
 
       def memoize_value(var_name, value)

--- a/spec/ghp_metadata_generator_spec.rb
+++ b/spec/ghp_metadata_generator_spec.rb
@@ -7,34 +7,20 @@ RSpec.describe(Jekyll::GitHubMetadata::GHPMetadataGenerator) do
   let(:source) { File.expand_path("../test-site", __FILE__) }
   let(:dest) { File.expand_path("../../tmp/test-site-build", __FILE__)}
   let(:user_config) { {} }
-  let(:configuration) do
-    merged_config = user_config.merge({source: source, dest: dest, quiet: true})
-    Jekyll.configuration(merged_config)
-  end
-  let(:site) { Jekyll::Site.new(configuration) }
+  let(:site) { Jekyll::Site.new(Jekyll::Configuration.from(user_config)) }
 
   it "is safe" do
     expect(described_class.safe).to be(true)
   end
 
   context "generating" do
-    before { stub_api("/repos/jekyll/github-metadata" , "repo") }
-    before { stub_api("/repos/jekyll/github-metadata/pages" , "repo_pages") }
-    before { stub_api("/repos/jekyll/jekyll.github.io" , "repo") }
-    before { stub_api("/repos/jekyll/jekyll.github.io/pages" , "repo_pages") }
-    before { stub_api("/repos/jekyll/jekyll.github.com" , "repo") }
-    before { stub_api("/repos/jekyll/jekyll.github.com/pages" , "repo_pages") }
-
-    before do
-      ENV["NO_NETRC"] = "true"
-      ENV["JEKYLL_GITHUB_TOKEN"] = "1234abc"
-      ENV["PAGES_REPO_NWO"] = "jekyll/github-metadata"
-      ENV["PAGES_ENV"] = "dotcom"
+    let!(:stubs) { stub_all_api_requests }
+    before(:each) do
+      subject.generate(site)
     end
-    before(:each) { site.process }
 
     context "with site.url set" do
-      let(:user_config) { { url: "http://example.com" } }
+      let(:user_config) { { "url" => "http://example.com" } }
 
       it "doesn't mangle site.url" do
         expect(site.config["url"]).to eql("http://example.com")
@@ -42,7 +28,7 @@ RSpec.describe(Jekyll::GitHubMetadata::GHPMetadataGenerator) do
     end
 
     context "with site.baseurl set" do
-      let(:user_config) { { baseurl: "/foo" } }
+      let(:user_config) { { "baseurl" => "/foo" } }
 
       it "doesn't mangle site.url" do
         expect(site.config["baseurl"]).to eql("/foo")

--- a/spec/ghp_metadata_generator_spec.rb
+++ b/spec/ghp_metadata_generator_spec.rb
@@ -4,8 +4,61 @@ require "jekyll-github-metadata/ghp_metadata_generator"
 
 RSpec.describe(Jekyll::GitHubMetadata::GHPMetadataGenerator) do
   subject { described_class.new }
+  let(:source) { File.expand_path("../test-site", __FILE__) }
+  let(:dest) { File.expand_path("../../tmp/test-site-build", __FILE__)}
+  let(:user_config) { {} }
+  let(:configuration) do
+    merged_config = user_config.merge({source: source, dest: dest, quiet: true})
+    Jekyll.configuration(merged_config)
+  end
+  let(:site) { Jekyll::Site.new(configuration) }
 
   it "is safe" do
     expect(described_class.safe).to be(true)
+  end
+
+  context "generating" do
+    before { stub_api("/repos/jekyll/github-metadata" , "repo") }
+    before { stub_api("/repos/jekyll/github-metadata/pages" , "repo_pages") }
+    before { stub_api("/repos/jekyll/jekyll.github.io" , "repo") }
+    before { stub_api("/repos/jekyll/jekyll.github.io/pages" , "repo_pages") }
+    before { stub_api("/repos/jekyll/jekyll.github.com" , "repo") }
+    before { stub_api("/repos/jekyll/jekyll.github.com/pages" , "repo_pages") }
+
+    before do
+      ENV["NO_NETRC"] = "true"
+      ENV["JEKYLL_GITHUB_TOKEN"] = "1234abc"
+      ENV["PAGES_REPO_NWO"] = "jekyll/github-metadata"
+      ENV["PAGES_ENV"] = "dotcom"
+    end
+    before(:each) { site.process }
+
+    context "with site.url set" do
+      let(:user_config) { { url: "http://example.com" } }
+
+      it "doesn't mangle site.url" do
+        expect(site.config["url"]).to eql("http://example.com")
+      end
+    end
+
+    context "with site.baseurl set" do
+      let(:user_config) { { baseurl: "/foo" } }
+
+      it "doesn't mangle site.url" do
+        expect(site.config["baseurl"]).to eql("/foo")
+      end
+    end
+
+    context "without site.url set" do
+      it "sets site.url" do
+        expect(site.config["url"]).to eql("http://example.com")
+      end
+    end
+
+    context "without site.baseurl set" do
+      it "sets site.baseurl" do
+        expect(site.config["baseurl"]).to eql("/foo")
+      end
+    end
   end
 end

--- a/spec/ghp_metadata_generator_spec.rb
+++ b/spec/ghp_metadata_generator_spec.rb
@@ -5,7 +5,7 @@ require "jekyll-github-metadata/ghp_metadata_generator"
 RSpec.describe(Jekyll::GitHubMetadata::GHPMetadataGenerator) do
   subject { described_class.new }
   let(:source) { File.expand_path("../test-site", __FILE__) }
-  let(:dest) { File.expand_path("../../tmp/test-site-build", __FILE__)}
+  let(:dest) { File.expand_path("../../tmp/test-site-build", __FILE__) }
   let(:user_config) { {} }
   let(:site) { Jekyll::Site.new(Jekyll::Configuration.from(user_config)) }
 
@@ -16,7 +16,11 @@ RSpec.describe(Jekyll::GitHubMetadata::GHPMetadataGenerator) do
   context "generating" do
     let!(:stubs) { stub_all_api_requests }
     before(:each) do
+      ENV["JEKYLL_ENV"] = "production"
       subject.generate(site)
+    end
+    after(:each) do
+      ENV.delete("JEKYLL_ENV")
     end
 
     context "with site.url set" do

--- a/spec/ghp_metadata_generator_spec.rb
+++ b/spec/ghp_metadata_generator_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe(Jekyll::GitHubMetadata::GHPMetadataGenerator) do
 
     context "without site.url set" do
       it "sets site.url" do
-        expect(site.config["url"]).to eql("http://example.com")
+        expect(site.config["url"]).to eql("http://jekyll.github.io/github-metadata")
       end
     end
 
     context "without site.baseurl set" do
       it "sets site.baseurl" do
-        expect(site.config["baseurl"]).to eql("/foo")
+        expect(site.config["baseurl"]).to eql("/github-metadata")
       end
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe("integration into a jekyll site") do
     "is_project_page"      => true,
     "show_downloads"       => true,
     "url"                  => "http://jekyll.github.io/github-metadata",
+    "baseurl"              => "/github-metadata",
     "contributors"         => %r!"login"=>"parkr", "id"=>237985!,
     "releases"             => %r!"tag_name"=>"v1.1.0"!
   }.each do |key, value|

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -10,30 +10,9 @@ RSpec.describe("integration into a jekyll site") do
     DEST_DIR.join(*files)
   end
 
-  API_STUBS = {
-    "/users/jekyll/repos?per_page=100&type=public"            => "owner_repos",
-    "/repos/jekyll/github-metadata"                           => "repo",
-    "/orgs/jekyll"                                            => "org",
-    "/orgs/jekyll/public_members?per_page=100"                => "org_members",
-    "/repos/jekyll/github-metadata/pages"                     => "repo_pages",
-    "/repos/jekyll/github-metadata/releases?per_page=100"     => "repo_releases",
-    "/repos/jekyll/github-metadata/contributors?per_page=100" => "repo_contributors",
-    "/repos/jekyll/jekyll.github.io"                          => "not_found",
-    "/repos/jekyll/jekyll.github.com"                         => "repo",
-    "/repos/jekyll/jekyll.github.com/pages"                   => "repo_pages",
-    "/repos/jekyll/jekyll.github.io/pages"                    => "repo_pages"
-  }.map { |path, file| ApiStub.new(path, file) }
+  let!(:stubs) { stub_all_api_requests }
 
   before(:each) do
-    # Reset some stuffs
-    ENV["NO_NETRC"] = "true"
-    ENV["JEKYLL_GITHUB_TOKEN"] = "1234abc"
-    ENV["PAGES_REPO_NWO"] = "jekyll/github-metadata"
-    ENV["PAGES_ENV"] = "dotcom"
-
-    # Stub Requests
-    API_STUBS.each { |stub| stub.stub = stub_api(stub.path, stub.file) }
-
     # Run Jekyll
     Jekyll.logger.log_level = :error
     Jekyll::Commands::Build.process({
@@ -89,8 +68,8 @@ RSpec.describe("integration into a jekyll site") do
   end
 
   it "calls all the stubs" do
-    API_STUBS.each do |stub|
-      expect(stub.stub).to have_been_requested
+    stubs.each do |stub|
+      expect(stub).to have_been_requested
     end
   end
 end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -4,13 +4,12 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
   let(:repo) { described_class.new(nwo) }
   before(:each) do
     ENV["JEKYLL_GITHUB_TOKEN"] = "allthespecs"
-    stub.stub = stub_api(stub.path, stub.file, stub.request_headers)
   end
 
   context "with the html_url preview API turned on" do
     let(:nwo) { "jekyll/jekyll" }
-    let(:stub) do
-      ApiStub.new(
+    let!(:stub) do
+      stub_api(
         "/repos/#{nwo}/pages",
         "jekyll_repo_pages",
         { "Accept" => "application/vnd.github.mister-fantastic-preview+json" }
@@ -37,8 +36,8 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
   end
 
   context "hubot.github.com" do
-    let(:nwo)  { "github/hubot.github.com" }
-    let(:stub) { ApiStub.new("/repos/#{nwo}/pages", "hubot_repo_pages") }
+    let(:nwo) { "github/hubot.github.com" }
+    let!(:stub) { stub_api("/repos/#{nwo}/pages", "hubot_repo_pages") }
 
     it "forces HTTPS for the URL" do
       expect(repo.html_url).to eql("https://hubot.github.com")
@@ -47,7 +46,7 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
 
   context "ben.balter.com" do
     let(:nwo) { "benbalter/benbalter.github.com" }
-    let(:stub) { ApiStub.new("/repos/#{nwo}/pages", "benbalter_repo_pages") }
+    let!(:stub) { stub_api("/repos/#{nwo}/pages", "benbalter_repo_pages") }
 
     it "returns the CNAME as its domain" do
       expect(repo.domain).to eql("ben.balter.com")
@@ -68,7 +67,7 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
 
   context "parkr.github.io" do
     let(:nwo) { "parkr/parkr.github.io" }
-    let(:stub) { ApiStub.new("/repos/#{nwo}/pages", "parkr_repo_pages") }
+    let!(:stub) { stub_api("/repos/#{nwo}/pages", "parkr_repo_pages") }
 
     it "returns the CNAME as its domain" do
       expect(repo.domain).to eql("parkermoore.de")
@@ -89,7 +88,7 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
 
   context "jldec.github.io" do
     let(:nwo) { "jldec/jldec.github.io" }
-    let(:stub) { ApiStub.new("/repos/#{nwo}/pages", "jldec_repo_pages") }
+    let!(:stub) { stub_api("/repos/#{nwo}/pages", "jldec_repo_pages") }
 
     it "returns the CNAME as its domain" do
       expect(repo.domain).to eql("jldec.github.io")
@@ -108,7 +107,7 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
     end
 
     context "on enterprise" do
-      let(:stub) { ApiStub.new("/repos/#{nwo}/pages", "jldec_enterprise_repo_pages") }
+      let!(:stub) { stub_api("/repos/#{nwo}/pages", "jldec_enterprise_repo_pages") }
 
       it "uses Pages.scheme when SSL set to determine scheme for Pages URL" do
         # With SSL=true

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
     it "uses Pages.scheme to determine scheme for domain" do
       expect(repo.html_url).to eql("http://ben.balter.com")
     end
+
+    it "parses the baseurl" do
+      expect(repo.baseurl).to eql("")
+    end
   end
 
   context "parkr.github.io" do
@@ -76,6 +80,10 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
 
     it "uses Pages.scheme to determine scheme for domain" do
       expect(repo.html_url).to eql("http://parkermoore.de")
+    end
+
+    it "parses the baseurl" do
+      expect(repo.baseurl).to eql("")
     end
   end
 
@@ -95,6 +103,10 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
       expect(repo.html_url).to eql("https://jldec.github.io")
     end
 
+    it "parses the baseurl" do
+      expect(repo.baseurl).to eql("")
+    end
+
     context "on enterprise" do
       let(:stub) { ApiStub.new("/repos/#{nwo}/pages", "jldec_enterprise_repo_pages") }
 
@@ -109,6 +121,7 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
           expect(Jekyll::GitHubMetadata::Pages.scheme).to eql("https")
           expect(repo.html_url).to eql("https://github.acme.com/pages/#{nwo}")
           expect(repo.url_scheme).to eql("https")
+          expect(repo.baseurl).to eql("/pages/#{nwo}")
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,14 +52,33 @@ module WebMockHelper
   end
 end
 
-class ApiStub
-  attr_reader :path, :file, :request_headers
-  attr_accessor :stub
+module StubHelper
+  include WebMockHelper
 
-  def initialize(path, file, req_headers = {})
-    @path = path
-    @file = file
-    @request_headers = req_headers || {}
+  # Returns all stubs created.
+  def stub_all_api_requests
+    reset_env_for_stubs
+    {
+      "/users/jekyll/repos?per_page=100&type=public"            => "owner_repos",
+      "/repos/jekyll/github-metadata"                           => "repo",
+      "/orgs/jekyll"                                            => "org",
+      "/orgs/jekyll/public_members?per_page=100"                => "org_members",
+      "/repos/jekyll/github-metadata/pages"                     => "repo_pages",
+      "/repos/jekyll/github-metadata/releases?per_page=100"     => "repo_releases",
+      "/repos/jekyll/github-metadata/contributors?per_page=100" => "repo_contributors",
+      "/repos/jekyll/jekyll.github.io"                          => "not_found",
+      "/repos/jekyll/jekyll.github.com"                         => "repo",
+      "/repos/jekyll/jekyll.github.com/pages"                   => "repo_pages",
+      "/repos/jekyll/jekyll.github.io/pages"                    => "repo_pages"
+    }.map { |path, file| stub_api(path, file) }
+  end
+
+  def reset_env_for_stubs
+    # Reset some stuffs
+    ENV["NO_NETRC"] = "true"
+    ENV["JEKYLL_GITHUB_TOKEN"] = "1234abc"
+    ENV["PAGES_REPO_NWO"] = "jekyll/github-metadata"
+    ENV["PAGES_ENV"] = "dotcom"
   end
 end
 
@@ -140,6 +159,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.include WebMockHelper
+  config.include StubHelper
   WebMock.enable!
   WebMock.disable_net_connect!
   config.include EnvHelper


### PR DESCRIPTION
This allows `relative_url` and `absolute_url` to "just work" in most cases, by silently setting `site.url` and `site.baseurl` if either are not already set by the user.

This is a quick spike, and could use:

- [x] Code review
- [x] Passing tests