### PR TITLE
Remove the `path` before setting `site.url`

### DIFF
--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -37,16 +37,11 @@ module Jekyll
       def set_url_and_baseurl_fallbacks!
         return unless Jekyll.env == "production"
 
-        parsed_url = URI(drop.url)
-
-        # baseurl tho
-        if site.config["baseurl"].to_s.empty? && !["", "/"].include?(parsed_url.path)
-          site.config["baseurl"] = parsed_url.path
+        repo = drop.send(:repository)
+        site.config["url"] ||= repo.url_without_path
+        if site.config["baseurl"].to_s.empty? && !["", "/"].include?(repo.baseurl)
+          site.config["baseurl"] = repo.baseurl
         end
-
-        # remove path so URL doesn't have baseurl in it
-        parsed_url.path = ""
-        site.config["url"] ||= parsed_url.to_s
       end
     end
   end

--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -16,12 +16,12 @@ module Jekyll
         # Set `site.url` and `site.baseurl` if unset and in production mode.
         if Jekyll.env == "production"
           html_url = URI(drop.url)
-          
+
           # baseurl tho
           if site.config["baseurl"].to_s.empty? && !["", "/"].include?(html_url.path)
-            site.config["baseurl"] = html_url.path 
+            site.config["baseurl"] = html_url.path
           end
-          
+
           # remove path so URL doesn't have baseurl in it
           html_url.path = ""
           site.config["url"] ||= html_url.to_s

--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -12,21 +12,7 @@ module Jekyll
         Jekyll::GitHubMetadata.log :debug, "Initializing..."
         @site = site
         site.config["github"] = github_namespace
-
-        # Set `site.url` and `site.baseurl` if unset and in production mode.
-        if Jekyll.env == "production"
-          html_url = URI(drop.url)
-
-          # baseurl tho
-          if site.config["baseurl"].to_s.empty? && !["", "/"].include?(html_url.path)
-            site.config["baseurl"] = html_url.path
-          end
-
-          # remove path so URL doesn't have baseurl in it
-          html_url.path = ""
-          site.config["url"] ||= html_url.to_s
-        end
-
+        set_url_and_baseurl_fallbacks!
         @site = nil
       end
 
@@ -45,6 +31,22 @@ module Jekyll
 
       def drop
         @drop ||= MetadataDrop.new(site)
+      end
+
+      # Set `site.url` and `site.baseurl` if unset and in production mode.
+      def set_url_and_baseurl_fallbacks!
+        return unless Jekyll.env == "production"
+
+        parsed_url = URI(drop.url)
+
+        # baseurl tho
+        if site.config["baseurl"].to_s.empty? && !["", "/"].include?(parsed_url.path)
+          site.config["baseurl"] = parsed_url.path
+        end
+
+        # remove path so URL doesn't have baseurl in it
+        parsed_url.path = ""
+        site.config["url"] ||= parsed_url.to_s
       end
     end
   end

--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -1,4 +1,5 @@
 require "jekyll"
+require "uri"
 
 module Jekyll
   module GitHubMetadata
@@ -14,8 +15,16 @@ module Jekyll
 
         # Set `site.url` and `site.baseurl` if unset and in production mode.
         if Jekyll.env == "production"
-          site.config["url"] ||= drop.url
-          site.config["baseurl"] = drop.baseurl if site.config["baseurl"].to_s.empty?
+          html_url = URI(drop.url)
+          
+          # baseurl tho
+          if site.config["baseurl"].to_s.empty? && !["", "/"].include?(html_url.path)
+            site.config["baseurl"] = html_url.path 
+          end
+          
+          # remove path so URL doesn't have baseurl in it
+          html_url.path = ""
+          site.config["url"] ||= html_url.to_s
         end
 
         @site = nil

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -152,7 +152,7 @@ module Jekyll
       end
 
       def url_without_path
-        uri.dup.tap {|u| u.path = "" }.to_s
+        uri.dup.tap { |u| u.path = "" }.to_s
       end
 
       def domain

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -151,6 +151,10 @@ module Jekyll
         @uri ||= URI(html_url)
       end
 
+      def url_without_path
+        uri.dup.tap {|u| u.path = "" }.to_s
+      end
+
       def domain
         uri.host
       end

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,5 +3,5 @@
 set -e
 
 script/test
-bundle exec rubocop -S -D
+script/fmt -S -D
 bundle exec gem build jekyll-github-metadata.gemspec

--- a/script/fmt
+++ b/script/fmt
@@ -1,0 +1,2 @@
+#!/bin/bash
+bundle exec rubocop $@

--- a/spec/ghp_metadata_generator_spec.rb
+++ b/spec/ghp_metadata_generator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe(Jekyll::GitHubMetadata::GHPMetadataGenerator) do
 
     context "without site.url set" do
       it "sets site.url" do
-        expect(site.config["url"]).to eql("http://jekyll.github.io/github-metadata")
+        expect(site.config["url"]).to eql("http://jekyll.github.io")
       end
     end
 


### PR DESCRIPTION
@benbalter Got a problem. Right now, if you have `https://benbalter.github.io/maps/` as `site.github.url`, you get:

- `baseurl = "/maps/"` ✅ 
- `url = "https://benbalter.github.io/maps/"` ❌ 

This means `minima` [is providing bad url's](https://github.com/jekyll/minima/blob/v1.2.0/_includes/head.html#L9-L13).