### PR TITLE
Add MetadataDrop#to_s which outputs pretty JSON representation

### DIFF
--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -13,6 +13,16 @@ module Jekyll
         super(nil)
       end
 
+      def to_s
+        require "json"
+        JSON.pretty_generate to_h
+      end
+      alias_method :to_str, :to_s
+
+      def content_methods
+        super - ["to_s", "to_str"]
+      end
+
       def keys
         super.sort
       end

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -20,7 +20,7 @@ module Jekyll
       alias_method :to_str, :to_s
 
       def content_methods
-        super - ["to_s", "to_str"]
+        super - %w(to_s to_str)
       end
 
       def keys

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -2,9 +2,25 @@ require "spec_helper"
 
 RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
   let(:overrides) { { "repository" => "jekyll/another-repo" } }
-  let(:config) { Jekyll::Configuration::DEFAULTS.merge(overrides) }
+  let(:config) { Jekyll::Configuration.from(overrides) }
   let(:site) { Jekyll::Site.new config }
   subject { described_class.new(site) }
+
+  context "in Liquid" do
+    before(:each) do
+      stub_all_api_requests
+      site.config.delete("repository")
+      site.config["github"] = subject
+    end
+
+    it "renders as-is in Liquid" do
+      payload = site.site_payload
+      expect(payload["site"]["github"]).to be_instance_of(described_class)
+      template = Liquid::Template.parse("{{ site.github }}")
+      result = template.render!(payload, :registers => {:site => site})
+      expect(result).to eql(subject.to_s)
+    end
+  end
 
   context "with no repository set" do
     before(:each) do
@@ -31,6 +47,11 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
       :ssh   => "git@github.com:foo/bar.git"
     }.each do |type, url|
       context "with a #{type} git URL" do
+        before(:each) do
+          site.config.delete("repository")
+          ENV["PAGES_REPO_NWO"] = nil
+        end
+
         it "parses the name with owner from the git URL" do
           allow(subject).to receive(:git_remote_url).and_return(url)
           expect(subject.send(:nwo, site)).to eql("foo/bar")

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
       payload = site.site_payload
       expect(payload["site"]["github"]).to be_instance_of(described_class)
       template = Liquid::Template.parse("{{ site.github }}")
-      result = template.render!(payload, :registers => {:site => site})
+      result = template.render!(payload, :registers => { :site => site })
       expect(result).to eql(subject.to_s)
     end
   end

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -13,12 +13,15 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
       site.config["github"] = subject
     end
 
-    it "renders as-is in Liquid" do
+    it "renders as a pretty JSON object in Liquid" do
+      require "json"
       payload = site.site_payload
       expect(payload["site"]["github"]).to be_instance_of(described_class)
-      template = Liquid::Template.parse("{{ site.github }}")
-      result = template.render!(payload, :registers => { :site => site })
-      expect(result).to eql(subject.to_s)
+      expect(
+        Liquid::Template.parse("{{ site.github }}").render!(
+          payload, :registers => { :site => site }
+        )
+      ).to eql(JSON.pretty_generate(subject.to_h))
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -164,6 +164,10 @@ RSpec.configure do |config|
   WebMock.disable_net_connect!
   config.include EnvHelper
 
+  config.before(:all) do
+    FileUtils.mkdir_p("tmp")
+  end
+
   config.before(:each) do
     Jekyll::GitHubMetadata.reset!
     Jekyll::GitHubMetadata.logger = Logger.new(StringIO.new) unless ENV["DEBUG"]


### PR DESCRIPTION
This fixes an issue where `{{ site.github }}` doesn't expand out to all the values in the Drop.

This is controlled by `Drop#to_s` which, by default, is `self.class.name`.

/cc @jekyll/gh-pages