### PR TITLE
Lock Octokit to v4.3.0

### DIFF
--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(%r{^(lib|bin)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "octokit", "~> 4.4.0"
+  spec.add_runtime_dependency "octokit", "~> 4.3.0"
   spec.add_runtime_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.1"
 
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(%r{^(lib|bin)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "octokit", "~> 4.0"
+  spec.add_runtime_dependency "octokit", "~> 4.4.0"
   spec.add_runtime_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.1"
 
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
v4.4.0 introduced a change where it requires preview headers for `GET /repos/o/r/pages`, which aren't required. This will break our requests to get Pages metadata, such as `cname`, `html_url`, etc.

PR which breaks it: https://github.com/octokit/octokit.rb/pull/815
PR which fixes it: https://github.com/octokit/octokit.rb/pull/822

/cc @jekyll/gh-pages