### PR TITLE
Revert "Lock Octokit to v4.3.0", but disallow v4.4.0

### DIFF
--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(%r{^(lib|bin)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "octokit", "~> 4.0"
+  spec.add_runtime_dependency "octokit", "~> 4.0", "!= 4.4.0"
   spec.add_runtime_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.1"
 
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(%r{^(lib|bin)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "octokit", "~> 4.3.0"
+  spec.add_runtime_dependency "octokit", "~> 4.0"
   spec.add_runtime_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.1"
 
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
Reverts jekyll/github-metadata#79, but allows octokit v4.4.1 which has the fix (https://github.com/octokit/octokit.rb/pull/822).

https://github.com/octokit/octokit.rb/releases/tag/v4.4.1

/cc @jekyll/gh-pages 