### PR TITLE
Respect source passed from the API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ inherit_gem:
 
 Metrics/LineLength:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -99,7 +99,7 @@ module Jekyll
       end
 
       def git_ref
-        user_page? ? "master" : "gh-pages"
+        source["branch"] if source
       end
 
       def user_page?
@@ -141,6 +141,14 @@ module Jekyll
       def cname
         return nil unless Pages.custom_domains_enabled?
         repo_pages_info["cname"]
+      end
+
+      def source
+        if repo_pages_info["source"]
+          repo_pages_info["source"]
+        else
+          { "branch" => user_page? ? "master" : "gh-pages" }
+        end
       end
 
       def html_url

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -99,7 +99,11 @@ module Jekyll
       end
 
       def git_ref
-        source["branch"] if source
+        if repo_pages_info["source"]
+          repo_pages_info["source"]["branch"]
+        else
+          user_page? ? "master" : "gh-pages"
+        end
       end
 
       def user_page?
@@ -141,14 +145,6 @@ module Jekyll
       def cname
         return nil unless Pages.custom_domains_enabled?
         repo_pages_info["cname"]
-      end
-
-      def source
-        if repo_pages_info["source"]
-          repo_pages_info["source"]
-        else
-          { "branch" => user_page? ? "master" : "gh-pages" }
-        end
       end
 
       def html_url

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
         :accept => "application/vnd.github.mister-fantastic-preview+json"
       })
     end
+
+    it "respects the source branch" do
+      expect(repo.git_ref).to eql("master")
+    end
   end
 
   context "hubot.github.com" do

--- a/spec/webmock/api_get_jekyll_repo_pages.json
+++ b/spec/webmock/api_get_jekyll_repo_pages.json
@@ -3,5 +3,9 @@
   "status": "built",
   "cname": "jekyllrb.com",
   "custom_404": false,
-  "html_url": "http://jekyllrb.com/"
+  "html_url": "http://jekyllrb.com/",
+  "source": {
+    "branch": "master",
+    "path": "/"
+  }
 }


### PR DESCRIPTION
The Pages API now exposes source branch and path metadata. We should use that to build the proper zip and tar URLs so we respect the source selector.