### PR TITLE
Remove log on Octokit::NotFound

### DIFF
--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -65,7 +65,7 @@ module Jekyll
       rescue Faraday::Error::ConnectionFailed, Octokit::TooManyRequests => e
         Jekyll::GitHubMetadata.log :warn, e.message
         default
-      rescue Octokit::NotFound => e
+      rescue Octokit::NotFound
         default
       end
 

--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -66,7 +66,6 @@ module Jekyll
         Jekyll::GitHubMetadata.log :warn, e.message
         default
       rescue Octokit::NotFound => e
-        Jekyll::GitHubMetadata.log :error, e.message
         default
       end
 


### PR DESCRIPTION
It looks scary even though it's often totally fine.