### PR TITLE
Add .configuration and .page_build? methods to Pages

### DIFF
--- a/lib/jekyll-github-metadata/ghp_metadata_generator.rb
+++ b/lib/jekyll-github-metadata/ghp_metadata_generator.rb
@@ -33,9 +33,9 @@ module Jekyll
         @drop ||= MetadataDrop.new(site)
       end
 
-      # Set `site.url` and `site.baseurl` if unset and in production mode.
+      # Set `site.url` and `site.baseurl` if unset.
       def set_url_and_baseurl_fallbacks!
-        return unless Jekyll.env == "production"
+        return unless Jekyll.env == "production" || Pages.page_build?
 
         repo = drop.send(:repository)
         site.config["url"] ||= repo.url_without_path

--- a/lib/jekyll-github-metadata/pages.rb
+++ b/lib/jekyll-github-metadata/pages.rb
@@ -75,6 +75,12 @@ module Jekyll
           trim_last_slash env_var("PAGES_PAGES_HOSTNAME", intermediate_default)
         end
 
+        def configuration
+          (methods - Object.methods - [:configuration]).each_with_object({}) do |meth, memo|
+            memo[meth.to_s] = public_send(meth)
+          end
+        end
+
         private
         def env_var(key, intermediate_default = nil)
           !ENV[key].to_s.empty? ? ENV[key] : (intermediate_default || DEFAULTS[key])

--- a/lib/jekyll-github-metadata/pages.rb
+++ b/lib/jekyll-github-metadata/pages.rb
@@ -10,7 +10,8 @@ module Jekyll
           "PAGES_PAGES_HOSTNAME"   => "github.io".freeze,
           "SSL"                    => "false".freeze,
           "SUBDOMAIN_ISOLATION"    => "false".freeze,
-          "PAGES_PREVIEW_HTML_URL" => nil
+          "PAGES_PREVIEW_HTML_URL" => nil,
+          "PAGE_BUILD_ID"          => nil
         }.freeze
 
         # Whether the GitHub instance supports HTTPS
@@ -75,8 +76,12 @@ module Jekyll
           trim_last_slash env_var("PAGES_PAGES_HOSTNAME", intermediate_default)
         end
 
+        def page_build?
+          !env_var("PAGE_BUILD_ID").to_s.empty?
+        end
+
         def configuration
-          (methods - Object.methods - [:configuration]).each_with_object({}) do |meth, memo|
+          (methods - Object.methods - [:configuration]).sort.each_with_object({}) do |meth, memo|
             memo[meth.to_s] = public_send(meth)
           end
         end

--- a/spec/pages_spec.rb
+++ b/spec/pages_spec.rb
@@ -26,6 +26,28 @@ RSpec.describe(Jekyll::GitHubMetadata::Pages) do
     end
   end
 
+  context ".configuration" do
+    it "returns the entire configuration" do
+      expect(described_class.configuration).to eql({
+        "api_url"                      => "https://api.github.com",
+        "custom_domains_enabled?"      => true,
+        "development?"                 => false,
+        "dotcom?"                      => false,
+        "enterprise?"                  => false,
+        "env"                          => "test",
+        "github_hostname"              => "github.com",
+        "github_url"                   => "https://github.com",
+        "help_url"                     => "https://help.github.com",
+        "pages_hostname"               => "github.io",
+        "repo_pages_html_url_preview?" => nil,
+        "scheme"                       => "https",
+        "ssl?"                         => true,
+        "subdomain_isolation?"         => false,
+        "test?"                        => true
+      })
+    end
+  end
+
   context ".env" do
     it "picks up on PAGES_ENV" do
       with_env("PAGES_ENV", "halp") do

--- a/spec/pages_spec.rb
+++ b/spec/pages_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe(Jekyll::GitHubMetadata::Pages) do
         "github_hostname"              => "github.com",
         "github_url"                   => "https://github.com",
         "help_url"                     => "https://help.github.com",
+        "page_build?"                  => false,
         "pages_hostname"               => "github.io",
         "repo_pages_html_url_preview?" => nil,
         "scheme"                       => "https",
@@ -133,6 +134,18 @@ RSpec.describe(Jekyll::GitHubMetadata::Pages) do
       with_env "PAGES_ENV", "development" do
         expect(described_class.pages_hostname).to eql("localhost:4000")
       end
+    end
+  end
+
+  context ".page_build?" do
+    it "returns true when $PAGE_BUILD_ID is set" do
+      with_env "PAGE_BUILD_ID", "123" do
+        expect(described_class.page_build?).to be(true)
+      end
+    end
+
+    it "returns false by default" do
+      expect(described_class.page_build?).to be(false)
     end
   end
 end


### PR DESCRIPTION
`.configuration` gives us a way to debug our metadata fetching by showing what the Pages configuration is.

`.page_build?` gives us a different way to enable automatically setting the `site.url` and `site.baseurl` values when running in development mode.

/cc @jldec