### PR TITLE
Add commits to site.github

### DIFF
--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -16,6 +16,7 @@ module Jekyll
         releases
         list_repos
         organization_public_members
+        commits
       ))
 
       def initialize(options = nil)

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -73,7 +73,7 @@ module Jekyll
       def_delegator :repository, :baseurl,                     :baseurl
       def_delegator :repository, :contributors,                :contributors
       def_delegator :repository, :releases,                    :releases
-
+      def_delegator :repository, :commits,                     :commits
       private
       attr_reader :site
 

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -98,6 +98,10 @@ module Jekyll
         memoize_value :@releases, Value.new(proc { |c| c.releases(nwo) })
       end
 
+      def commits
+        memoize_value :@commits, Value.new(proc { |c| c.commits(nwo) })
+      end
+
       def git_ref
         if repo_pages_info["source"]
           repo_pages_info["source"]["branch"]


### PR DESCRIPTION
I'd like to propose that commits be added to site.github. The main reason for this would be for display your commit history on your generated site.

Currently I am building an internal documentation site and thought it would be great to have a recent activity feed or history feed.