### PR TITLE
Set default site.title and site.description

### DIFF
--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -15,7 +15,10 @@ module Jekyll
 
         # This is the good stuff.
         site.config["github"] = github_namespace
+
+        return unless should_add_fallbacks?
         add_url_and_baseurl_fallbacks!
+        add_title_and_description_fallbacks!
       end
 
       private
@@ -37,13 +40,24 @@ module Jekyll
 
       # Set `site.url` and `site.baseurl` if unset.
       def add_url_and_baseurl_fallbacks!
-        return unless Jekyll.env == "production" || Pages.page_build?
-
         repo = drop.send(:repository)
         site.config["url"] ||= repo.url_without_path
         if site.config["baseurl"].to_s.empty? && !["", "/"].include?(repo.baseurl)
           site.config["baseurl"] = repo.baseurl
         end
+      end
+
+      def add_title_and_description_fallbacks!
+        site.config["title"] ||= repository.name
+        site.config["description"] ||= repository.tagline
+      end
+
+      def should_add_fallbacks?
+        Jekyll.env == "production" || Pages.page_build?
+      end
+
+      def repository
+        drop.send(:repository)
       end
     end
   end

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -43,6 +43,24 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
         expect(site.config["baseurl"]).to eql("/github-metadata")
       end
     end
+
+    context "title and description" do
+      context "with title and description set" do
+        let(:user_config) do
+          { "title" => "My title", "description" => "My description" }
+        end
+
+        it "respects the title and tagline" do
+          expect(site.config["title"]).to eql("My title")
+          expect(site.config["description"]).to eql("My description")
+        end
+      end
+
+      it "sets the title and description" do
+        expect(site.config["title"]).to eql("github-metadata")
+        expect(site.config["description"]).to eql(":octocat: `site.github`")
+      end
+    end
   end
 
   context "with a client with no credentials" do


### PR DESCRIPTION
For use with things like Jekyll SEO Tag in default templates.