### PR TITLE
Remove latest release url

### DIFF
--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -63,7 +63,6 @@ module Jekyll
       def_delegator :repository, :tar_url,                     :tar_url
       def_delegator :repository, :repo_clone_url,              :clone_url
       def_delegator :repository, :releases_url,                :releases_url
-      def_delegator :repository, :latest_release_url,          :latest_release_url
       def_delegator :repository, :issues_url,                  :issues_url
       def_delegator :repository, :wiki_url,                    :wiki_url
       def_delegator :repository, :language,                    :language


### PR DESCRIPTION
Added via https://github.com/jekyll/github-metadata/pull/88. Users can use `site.github.latest_release.url` if they really want it, but I suspect what they want is `site.github.latest_release.html_url`. Feels silly to expose the API url as `site.github.latest_release_url`.