### PR TITLE
Set title and description in dev

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--order random

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ Metrics/LineLength:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*
+    
+Metrics/MethodLength:
+    Exclude:
+      - spec/**/

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -24,6 +24,7 @@ module Jekyll
     autoload :MetadataDrop,     "jekyll-github-metadata/metadata_drop"
     autoload :Pages,            "jekyll-github-metadata/pages"
     autoload :Repository,       "jekyll-github-metadata/repository"
+    autoload :RepositoryFinder, "jekyll-github-metadata/repository_finder"
     autoload :RepositoryCompat, "jekyll-github-metadata/repository_compat"
     autoload :Sanitizer,        "jekyll-github-metadata/sanitizer"
     autoload :Value,            "jekyll-github-metadata/value"
@@ -34,7 +35,7 @@ module Jekyll
     end
 
     class << self
-      attr_accessor :repository
+      attr_accessor :site
       attr_writer :client, :logger
 
       def environment
@@ -61,9 +62,18 @@ module Jekyll
         @client ||= Client.new
       end
 
+      def repository
+        @repository ||= GitHubMetadata::Repository.new(nwo).tap do |repo|
+          Jekyll::GitHubMetadata.log :debug, "Generating for #{repo.nwo}"
+        end
+      end
+
+      def nwo
+        @nwo ||= GitHubMetadata::RepositoryFinder.nwo
+      end
+
       def reset!
-        @logger = nil
-        @client = nil
+        @logger = @client = @repository = @nwo = @site = nil
       end
     end
   end

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -8,8 +8,7 @@ module Jekyll
 
       mutable true
 
-      def initialize(site)
-        @site = site
+      def initialize(_site)
         super(nil)
       end
 
@@ -34,20 +33,7 @@ module Jekyll
       def_delegator :"Jekyll::GitHubMetadata::Pages", :api_url, :api_url
       def_delegator :"Jekyll::GitHubMetadata::Pages", :help_url, :help_url
 
-      def versions
-        @versions ||= begin
-          require "github-pages"
-          GitHubPages.versions
-        rescue LoadError
-          {}
-        end
-      end
-
-      def build_revision
-        @build_revision ||= begin
-          ENV["JEKYLL_BUILD_REVISION"] || `git rev-parse HEAD`.strip
-        end
-      end
+      private def_delegator :"Jekyll::GitHubMetadata", :repository
 
       def_delegator :repository, :owner_public_repositories,   :public_repositories
       def_delegator :repository, :organization_public_members, :organization_members
@@ -75,66 +61,22 @@ module Jekyll
       def_delegator :repository, :releases,                    :releases
       def_delegator :repository, :latest_release,              :latest_release
 
-      private
-      attr_reader :site
-
-      def repository
-        @repository ||= GitHubMetadata::Repository.new(nwo(site)).tap do |repo|
-          Jekyll::GitHubMetadata.log :debug, "Generating for #{repo.nwo}"
+      def versions
+        @versions ||= begin
+          require "github-pages"
+          GitHubPages.versions
+        rescue LoadError
+          {}
         end
       end
 
-      def git_exe_path
-        ENV["PATH"].to_s.split(File::PATH_SEPARATOR).map { |path| File.join(path, "git") }.find { |path| File.exist?(path) }
+      def build_revision
+        @build_revision ||= begin
+          ENV["JEKYLL_BUILD_REVISION"] || `git rev-parse HEAD`.strip
+        end
       end
 
-      def git_remotes
-        return [] if git_exe_path.nil?
-        `#{git_exe_path} remote --verbose`.to_s.strip.split("\n")
-      end
-
-      def git_remote_url
-        git_remotes.grep(%r!\Aorigin\t!).map do |remote|
-          remote.sub(%r!\Aorigin\t(.*) \([a-z]+\)!, "\\1")
-        end.uniq.first || ""
-      end
-
-      def nwo_from_git_origin_remote
-        return unless Jekyll.env == "development" || Jekyll.env == "test"
-        matches = git_remote_url.chomp(".git").match %r!github.com(:|/)([\w-]+)/([\w\.-]+)!
-        matches[2..3].join("/") if matches
-      end
-
-      def nwo_from_env
-        ENV["PAGES_REPO_NWO"]
-      end
-
-      def nwo_from_config(site)
-        repo = site.config["repository"]
-        repo if repo && repo.is_a?(String) && repo.include?("/")
-      end
-
-      # Public: fetches the repository name with owner to fetch metadata for.
-      # In order of precedence, this method uses:
-      # 1. the environment variable $PAGES_REPO_NWO
-      # 2. 'repository' variable in the site config
-      # 3. the 'origin' git remote's URL
-      #
-      # site - the Jekyll::Site being processed
-      #
-      # Return the name with owner (e.g. 'parkr/my-repo') or raises an
-      # error if one cannot be found.
-      def nwo(site)
-        nwo_from_env || \
-          nwo_from_config(site) || \
-          nwo_from_git_origin_remote || \
-          proc do
-            raise GitHubMetadata::NoRepositoryError, "No repo name found. " \
-              "Specify using PAGES_REPO_NWO environment variables, " \
-              "'repository' in your configuration, or set up an 'origin' " \
-              "git remote pointing to your github.com repository."
-          end.call
-      end
+      private
 
       # Nothing to see here.
       def fallback_data

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -8,11 +8,6 @@ module Jekyll
 
       mutable true
 
-      def initialize(site = nil)
-        GitHubMetadata.site = site unless site.nil?
-        super(nil)
-      end
-
       def to_s
         require "json"
         JSON.pretty_generate to_h

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -8,7 +8,8 @@ module Jekyll
 
       mutable true
 
-      def initialize(_site)
+      def initialize(site = nil)
+        GitHubMetadata.site = site
         super(nil)
       end
 

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -9,7 +9,7 @@ module Jekyll
       mutable true
 
       def initialize(site = nil)
-        GitHubMetadata.site = site
+        GitHubMetadata.site = site unless site.nil?
         super(nil)
       end
 

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -1,0 +1,65 @@
+module Jekyll
+  module GitHubMetadata
+    class RepositoryFinder
+      class << self
+        # Public: fetches the repository name with owner to fetch metadata for.
+        # In order of precedence, this method uses:
+        # 1. the environment variable $PAGES_REPO_NWO
+        # 2. 'repository' variable in the site config
+        # 3. the 'origin' git remote's URL
+        #
+        # site - the Jekyll::Site being processed
+        #
+        # Return the name with owner (e.g. 'parkr/my-repo') or raises an
+        # error if one cannot be found.
+        def nwo
+          nwo_from_env || \
+            nwo_from_config(site) || \
+            nwo_from_git_origin_remote || \
+            proc do
+              raise GitHubMetadata::NoRepositoryError, "No repo name found. " \
+                "Specify using PAGES_REPO_NWO environment variables, " \
+                "'repository' in your configuration, or set up an 'origin' " \
+                "git remote pointing to your github.com repository."
+            end.call
+        end
+
+        private
+
+        def git_exe_path
+          ENV["PATH"].to_s.split(File::PATH_SEPARATOR).map { |path| File.join(path, "git") }.find { |path| File.exist?(path) }
+        end
+
+        def git_remotes
+          return [] if git_exe_path.nil?
+          `#{git_exe_path} remote --verbose`.to_s.strip.split("\n")
+        end
+
+        def git_remote_url
+          git_remotes.grep(%r!\Aorigin\t!).map do |remote|
+            remote.sub(%r!\Aorigin\t(.*) \([a-z]+\)!, "\\1")
+          end.uniq.first || ""
+        end
+
+        def nwo_from_git_origin_remote
+          return unless Jekyll.env == "development" || Jekyll.env == "test"
+          matches = git_remote_url.chomp(".git").match %r!github.com(:|/)([\w-]+)/([\w\.-]+)!
+          matches[2..3].join("/") if matches
+        end
+
+        def nwo_from_env
+          ENV["PAGES_REPO_NWO"]
+        end
+
+        def nwo_from_config(site)
+          repo = site.config["repository"]
+          repo if repo && repo.is_a?(String) && repo.include?("/")
+        end
+
+        def site
+          GitHubMetadata.site
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -1,64 +1,70 @@
 module Jekyll
   module GitHubMetadata
     class RepositoryFinder
-      class << self
-        # Public: fetches the repository name with owner to fetch metadata for.
-        # In order of precedence, this method uses:
-        # 1. the environment variable $PAGES_REPO_NWO
-        # 2. 'repository' variable in the site config
-        # 3. the 'origin' git remote's URL
-        #
-        # site - the Jekyll::Site being processed
-        #
-        # Return the name with owner (e.g. 'parkr/my-repo') or raises an
-        # error if one cannot be found.
-        def nwo
+      NoRepositoryError = Class.new(Jekyll::Errors::FatalException)
+
+      attr_reader :site
+      def initialize(site)
+        @site = site
+      end
+
+      # Public: fetches the repository name with owner to fetch metadata for.
+      # In order of precedence, this method uses:
+      # 1. the environment variable $PAGES_REPO_NWO
+      # 2. 'repository' variable in the site config
+      # 3. the 'origin' git remote's URL
+      #
+      # site - the Jekyll::Site being processed
+      #
+      # Return the name with owner (e.g. 'parkr/my-repo') or raises an
+      # error if one cannot be found.
+      def nwo
+        @nwo ||= begin
           nwo_from_env || \
-            nwo_from_config(site) || \
+            nwo_from_config || \
             nwo_from_git_origin_remote || \
             proc do
-              raise GitHubMetadata::NoRepositoryError, "No repo name found. " \
+              raise NoRepositoryError, "No repo name found. " \
                 "Specify using PAGES_REPO_NWO environment variables, " \
                 "'repository' in your configuration, or set up an 'origin' " \
                 "git remote pointing to your github.com repository."
             end.call
         end
+      end
 
-        private
+      private
 
-        def git_exe_path
-          ENV["PATH"].to_s.split(File::PATH_SEPARATOR).map { |path| File.join(path, "git") }.find { |path| File.exist?(path) }
-        end
+      def nwo_from_env
+        ENV["PAGES_REPO_NWO"]
+      end
 
-        def git_remotes
-          return [] if git_exe_path.nil?
-          `#{git_exe_path} remote --verbose`.to_s.strip.split("\n")
-        end
+      def nwo_from_config
+        repo = site.config["repository"]
+        repo if repo && repo.is_a?(String) && repo.include?("/")
+      end
 
-        def git_remote_url
-          git_remotes.grep(%r!\Aorigin\t!).map do |remote|
-            remote.sub(%r!\Aorigin\t(.*) \([a-z]+\)!, "\\1")
-          end.uniq.first || ""
-        end
+      def git_exe_path
+        ENV["PATH"].to_s
+          .split(File::PATH_SEPARATOR)
+          .map { |path| File.join(path, "git") }
+          .find { |path| File.exist?(path) }
+      end
 
-        def nwo_from_git_origin_remote
-          return unless Jekyll.env == "development" || Jekyll.env == "test"
-          matches = git_remote_url.chomp(".git").match %r!github.com(:|/)([\w-]+)/([\w\.-]+)!
-          matches[2..3].join("/") if matches
-        end
+      def git_remotes
+        return [] if git_exe_path.nil?
+        `#{git_exe_path} remote --verbose`.to_s.strip.split("\n")
+      end
 
-        def nwo_from_env
-          ENV["PAGES_REPO_NWO"]
-        end
+      def git_remote_url
+        git_remotes.grep(%r!\Aorigin\t!).map do |remote|
+          remote.sub(%r!\Aorigin\t(.*) \([a-z]+\)!, "\\1")
+        end.uniq.first || ""
+      end
 
-        def nwo_from_config(site)
-          repo = site.config["repository"]
-          repo if repo && repo.is_a?(String) && repo.include?("/")
-        end
-
-        def site
-          GitHubMetadata.site
-        end
+      def nwo_from_git_origin_remote
+        return unless Jekyll.env == "development" || Jekyll.env == "test"
+        matches = git_remote_url.chomp(".git").match %r!github.com(:|/)([\w-]+)/([\w\.-]+)!
+        matches[2..3].join("/") if matches
       end
     end
   end

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -12,6 +12,7 @@ module Jekyll
 
       def munge!
         Jekyll::GitHubMetadata.log :debug, "Initializing..."
+        Jekyll::GitHubMetadata.repository = repository
 
         # This is the good stuff.
         site.config["github"] = github_namespace
@@ -39,8 +40,8 @@ module Jekyll
 
       # Set `site.url` and `site.baseurl` if unset.
       def add_url_and_baseurl_fallbacks!
-        site.config["url"] ||= Value.new(proc { repository.url_without_path })
-        site.config["baseurl"] = Value.new(proc { repository.baseurl }) if should_set_baseurl?
+        site.config["url"] ||= Value.new(proc { |_c, r| r.url_without_path })
+        site.config["baseurl"] = Value.new(proc { |_c, r| r.baseurl }) if should_set_baseurl?
       end
 
       # Set the baseurl only if it is `nil` or `/`
@@ -50,8 +51,8 @@ module Jekyll
       end
 
       def add_title_and_description_fallbacks!
-        site.config["title"] ||= Value.new(proc { repository.name })
-        site.config["description"] ||= Value.new(proc { repository.tagline })
+        site.config["title"] ||= Value.new(proc { |_c, r| r.name })
+        site.config["description"] ||= Value.new(proc { |_c, r| r.tagline })
       end
 
       def should_add_url_fallbacks?

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -16,9 +16,8 @@ module Jekyll
         # This is the good stuff.
         site.config["github"] = github_namespace
 
-        return unless should_add_fallbacks?
-        add_url_and_baseurl_fallbacks!
         add_title_and_description_fallbacks!
+        add_url_and_baseurl_fallbacks! if should_add_url_fallbacks?
       end
 
       private
@@ -55,7 +54,7 @@ module Jekyll
         site.config["description"] ||= repository.tagline
       end
 
-      def should_add_fallbacks?
+      def should_add_url_fallbacks?
         Jekyll.env == "production" || Pages.page_build?
       end
 

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -6,7 +6,8 @@ module Jekyll
     class SiteGitHubMunger
       extend Forwardable
 
-      def_delegators :"Jekyll::GitHubMetadata", :site, :repository
+      def_delegators :"Jekyll::GitHubMetadata", :site
+      private def_delegator :"Jekyll::GitHubMetadata", :repository
 
       def initialize(site)
         Jekyll::GitHubMetadata.site = site

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -37,7 +37,7 @@ module Jekyll
       end
 
       def drop
-        @drop ||= MetadataDrop.new
+        @drop ||= MetadataDrop.new(GitHubMetadata.site)
       end
 
       # Set `site.url` and `site.baseurl` if unset.

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -40,7 +40,7 @@ module Jekyll
       # Set `site.url` and `site.baseurl` if unset.
       def add_url_and_baseurl_fallbacks!
         site.config["url"] ||= Value.new(proc { repository.url_without_path })
-        site.config["baseurl"] = repository.baseurl if should_set_baseurl?
+        site.config["baseurl"] = Value.new(proc { repository.baseurl }) if should_set_baseurl?
       end
 
       # Set the baseurl only if it is `nil` or `/`

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -39,7 +39,7 @@ module Jekyll
 
       # Set `site.url` and `site.baseurl` if unset.
       def add_url_and_baseurl_fallbacks!
-        site.config["url"] ||= repository.url_without_path
+        site.config["url"] ||= Value.new(proc { repository.url_without_path })
         site.config["baseurl"] = repository.baseurl if should_set_baseurl?
       end
 
@@ -50,8 +50,8 @@ module Jekyll
       end
 
       def add_title_and_description_fallbacks!
-        site.config["title"] ||= repository.name
-        site.config["description"] ||= repository.tagline
+        site.config["title"] ||= Value.new(proc { repository.name })
+        site.config["description"] ||= Value.new(proc { repository.tagline })
       end
 
       def should_add_url_fallbacks?

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -41,8 +41,9 @@ module Jekyll
 
       # Set `site.url` and `site.baseurl` if unset.
       def add_url_and_baseurl_fallbacks!
-        site.config["url"] ||= Value.new(proc { |_c, r| r.url_without_path })
-        site.config["baseurl"] = Value.new(proc { |_c, r| r.baseurl }) if should_set_baseurl?
+        site.config["url"] ||= Value.new("url", proc { |_c, r| r.url_without_path })
+        return unless should_set_baseurl?
+        site.config["baseurl"] = Value.new("baseurl", proc { |_c, r| r.baseurl })
       end
 
       # Set the baseurl only if it is `nil` or `/`
@@ -52,8 +53,8 @@ module Jekyll
       end
 
       def add_title_and_description_fallbacks!
-        site.config["title"] ||= Value.new(proc { |_c, r| r.name })
-        site.config["description"] ||= Value.new(proc { |_c, r| r.tagline })
+        site.config["title"] ||= Value.new("title", proc { |_c, r| r.name })
+        site.config["description"] ||= Value.new("description", proc { |_c, r| r.tagline })
       end
 
       def should_add_url_fallbacks?

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -4,15 +4,16 @@ require "uri"
 module Jekyll
   module GitHubMetadata
     class SiteGitHubMunger
-      attr_reader :site
+      extend Forwardable
+
+      def_delegators :"Jekyll::GitHubMetadata", :site, :repository
 
       def initialize(site)
-        @site = site
+        Jekyll::GitHubMetadata.site = site
       end
 
       def munge!
         Jekyll::GitHubMetadata.log :debug, "Initializing..."
-        Jekyll::GitHubMetadata.repository = repository
 
         # This is the good stuff.
         site.config["github"] = github_namespace
@@ -57,10 +58,6 @@ module Jekyll
 
       def should_add_url_fallbacks?
         Jekyll.env == "production" || Pages.page_build?
-      end
-
-      def repository
-        drop.send(:repository)
       end
     end
   end

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -36,7 +36,7 @@ module Jekyll
       end
 
       def drop
-        @drop ||= MetadataDrop.new(site)
+        @drop ||= MetadataDrop.new
       end
 
       # Set `site.url` and `site.baseurl` if unset.

--- a/lib/jekyll-github-metadata/value.rb
+++ b/lib/jekyll-github-metadata/value.rb
@@ -3,6 +3,9 @@ require "json"
 module Jekyll
   module GitHubMetadata
     class Value
+      extend Forwardable
+      def_delegators :render, :+, :to_s, :to_json
+
       attr_reader :key, :value
 
       def initialize(*args)
@@ -37,14 +40,6 @@ module Jekyll
       rescue RuntimeError, NameError => e
         Jekyll::GitHubMetadata.log :error, "Error processing value '#{key}':"
         raise e
-      end
-
-      def to_s
-        render.to_s
-      end
-
-      def to_json(*)
-        render.to_json
       end
 
       def to_liquid

--- a/lib/jekyll-github-metadata/value.rb
+++ b/lib/jekyll-github-metadata/value.rb
@@ -31,13 +31,7 @@ module Jekyll
 
       def to_liquid
         case render
-        when nil
-          nil
-        when true, false
-          value
-        when Hash
-          value
-        when String, Numeric, Array
+        when nil, true, false, Hash, String, Numeric, Array
           value
         else
           to_json

--- a/lib/jekyll-github-metadata/value.rb
+++ b/lib/jekyll-github-metadata/value.rb
@@ -4,7 +4,7 @@ module Jekyll
   module GitHubMetadata
     class Value
       extend Forwardable
-      def_delegators :render, :+, :to_s, :to_json, :eql?
+      def_delegators :render, :+, :to_s, :to_json, :eql?, :hash
 
       attr_reader :key, :value
 

--- a/lib/jekyll-github-metadata/value.rb
+++ b/lib/jekyll-github-metadata/value.rb
@@ -4,7 +4,7 @@ module Jekyll
   module GitHubMetadata
     class Value
       extend Forwardable
-      def_delegators :render, :+, :to_s, :to_json
+      def_delegators :render, :+, :to_s, :to_json, :eql?
 
       attr_reader :key, :value
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe("integration into a jekyll site") do
   before(:each) do
     # Run Jekyll
     ENV.delete("JEKYLL_ENV")
+    ENV["JEKYLL_ENV"] = "production"
     ENV["PAGES_ENV"] = "dotcom"
     Jekyll.logger.log_level = :error
     Jekyll::Commands::Build.process({

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe("integration into a jekyll site") do
 
   let!(:stubs) { stub_all_api_requests }
 
-  before(:each) do
+  before do
     # Run Jekyll
     ENV.delete("JEKYLL_ENV")
     ENV["PAGES_ENV"] = "dotcom"
@@ -24,7 +24,7 @@ RSpec.describe("integration into a jekyll site") do
       "plugins"     => %w(jekyll-github-metadata),
     })
   end
-  after(:each) do
+  after do
     ENV.delete("PAGES_ENV")
     ENV["JEKYLL_ENV"] = "test"
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -30,40 +30,7 @@ RSpec.describe("integration into a jekyll site") do
   end
   subject { SafeYAML.load(dest_dir("rendered.txt").read) }
 
-  {
-    "environment"          => "dotcom",
-    "hostname"             => "github.com",
-    "pages_env"            => "dotcom",
-    "pages_hostname"       => "github.io",
-    "help_url"             => "https://help.github.com",
-    "api_url"              => "https://api.github.com",
-    "versions"             => {},
-    "public_repositories"  => Regexp.new('"id"=>17261694, "name"=>"atom-jekyll"'),
-    "organization_members" => Regexp.new('"login"=>"parkr", "id"=>237985'),
-    "build_revision"       => %r![a-f0-9]{40}!,
-    "project_title"        => "github-metadata",
-    "project_tagline"      => ":octocat: `site.github`",
-    "owner_name"           => "jekyll",
-    "owner_url"            => "https://github.com/jekyll",
-    "owner_gravatar_url"   => "https://github.com/jekyll.png",
-    "repository_url"       => "https://github.com/jekyll/github-metadata",
-    "repository_nwo"       => "jekyll/github-metadata",
-    "repository_name"      => "github-metadata",
-    "zip_url"              => "https://github.com/jekyll/github-metadata/zipball/gh-pages",
-    "tar_url"              => "https://github.com/jekyll/github-metadata/tarball/gh-pages",
-    "clone_url"            => "https://github.com/jekyll/github-metadata.git",
-    "releases_url"         => "https://github.com/jekyll/github-metadata/releases",
-    "issues_url"           => "https://github.com/jekyll/github-metadata/issues",
-    "wiki_url"             => nil, # disabled
-    "language"             => "Ruby",
-    "is_user_page"         => false,
-    "is_project_page"      => true,
-    "show_downloads"       => true,
-    "url"                  => "http://jekyll.github.io/github-metadata",
-    "baseurl"              => "/github-metadata",
-    "contributors"         => %r!"login"=>"parkr", "id"=>237985!,
-    "releases"             => %r!"tag_name"=>"v1.1.0"!,
-  }.each do |key, value|
+  expected_values.each do |key, value|
     it "contains the correct #{key}" do
       expect(subject).to have_key(key)
       if value.is_a? Regexp

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe("integration into a jekyll site") do
 
   let!(:stubs) { stub_all_api_requests }
 
-  before do
+  before(:each) do
     # Run Jekyll
     ENV.delete("JEKYLL_ENV")
     ENV["PAGES_ENV"] = "dotcom"
@@ -24,7 +24,7 @@ RSpec.describe("integration into a jekyll site") do
       "plugins"     => %w(jekyll-github-metadata),
     })
   end
-  after do
+  after(:each) do
     ENV.delete("PAGES_ENV")
     ENV["JEKYLL_ENV"] = "test"
   end

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -5,11 +5,10 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
   let(:config) { Jekyll::Configuration.from(overrides) }
   let(:site) { Jekyll::Site.new config }
   subject { described_class.new(site) }
-  before { stub_all_api_requests }
-  before { stub_api "/repos/jekyll/another-repo", "repo" }
 
   context "in Liquid" do
     before(:each) do
+      stub_all_api_requests
       site.config.delete("repository")
       site.config["github"] = subject
     end
@@ -68,7 +67,6 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
 
   context "with PAGES_REPO_NWO and site.repository set" do
     before(:each) { ENV["PAGES_REPO_NWO"] = "jekyll/some-repo" }
-    before { stub_api "/repos/jekyll/some-repo", "repo" }
 
     it "uses the value from PAGES_REPO_NWO" do
       expect(subject.send(:nwo, site)).to eql("jekyll/some-repo")

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
   let(:config) { Jekyll::Configuration.from(overrides) }
   let(:site) { Jekyll::Site.new config }
   subject { described_class.new(site) }
+  before { Jekyll::GitHubMetadata.site = site }
+  before { stub_all_api_requests }
 
   context "in Liquid" do
     before(:each) do
-      stub_all_api_requests
       site.config.delete("repository")
       site.config["github"] = subject
     end
@@ -25,83 +26,27 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
     end
   end
 
-  context "with no repository set" do
-    before(:each) do
-      site.config.delete("repository")
-      ENV["PAGES_REPO_NWO"] = nil
-    end
+  context "payload" do
+    let!(:payload) { subject.to_h }
 
-    context "without a git nwo" do
-      it "raises a NoRepositoryError" do
-        allow(subject).to receive(:git_remote_url).and_return("")
-        expect(lambda do
-          subject.send(:nwo, site)
-        end).to raise_error(Jekyll::GitHubMetadata::NoRepositoryError)
+    expected_values.each do |key, value|
+      it "contains the #{key} key" do
+        expect(payload).to have_key(key)
       end
-    end
 
-    it "retrieves the git remote" do
-      allow(subject).to receive(:git_remote_url).and_call_original
-      expect(subject.send(:git_remote_url)).to include("jekyll/github-metadata")
-    end
-
-    {
-      :https => "https://github.com/foo/bar",
-      :ssh   => "git@github.com:foo/bar.git",
-    }.each do |type, url|
-      context "with a #{type} git URL" do
-        before(:each) do
-          site.config.delete("repository")
-          ENV["PAGES_REPO_NWO"] = nil
-          ENV.delete("JEKYLL_ENV")
-        end
-        after(:each) { ENV["JEKYLL_ENV"] = "test" }
-
-        it "parses the name with owner from the git URL" do
-          allow(subject).to receive(:git_remote_url).and_return(url)
-          expect(subject.send(:nwo, site)).to eql("foo/bar")
+      it "contains the correct value for #{key}" do
+        if value.is_a? Regexp
+          expect(payload[key].to_s).to match value
+        else
+          expect(payload[key]).to eql value
         end
       end
     end
-  end
 
-  context "with PAGES_REPO_NWO and site.repository set" do
-    before(:each) { ENV["PAGES_REPO_NWO"] = "jekyll/some-repo" }
-
-    it "uses the value from PAGES_REPO_NWO" do
-      expect(subject.send(:nwo, site)).to eql("jekyll/some-repo")
-    end
-  end
-
-  context "with only site.repository set" do
-    before(:each) { ENV["PAGES_REPO_NWO"] = nil }
-
-    it "uses the value from site.repository" do
-      expect(subject.send(:nwo, site)).to eql("jekyll/another-repo")
-    end
-  end
-
-  context "when determining the nwo via git" do
-    before(:each) { ENV.delete("JEKYLL_ENV") }
-    after(:each) { ENV["JEKYLL_ENV"] = "test" }
-
-    it "handles periods in repo names" do
-      allow(subject).to receive(:git_remote_url).and_return <<-EOS
-  origin  https://github.com/afeld/hackerhours.org.git (fetch)
-  origin  https://github.com/afeld/hackerhours.org.git (push)
-  EOS
-      expect(subject.send(:nwo_from_git_origin_remote)).to include("afeld/hackerhours.org")
-    end
-
-    context "when git doesn't exist" do
-      before(:each) { @old_path = ENV.delete("PATH").to_s.split(File::PATH_SEPARATOR) }
-      after(:each)  { ENV["PATH"] = @old_path.join(File::PATH_SEPARATOR) }
-
-      it "fails with a nice error message" do
-        allow(subject).to receive(:git_remote_url).and_call_original
-        expect(subject.send(:git_exe_path)).to eql(nil)
-        expect(subject.send(:git_remote_url)).to be_empty
-      end
+    # Test to ensure we're testing all the values in the drop payload
+    # If this test fails, you likely need to update a value in spec_helper.rb
+    it "validates all values" do
+      expect(payload.keys).to match_array(expected_values.keys)
     end
   end
 end

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
   let(:config) { Jekyll::Configuration.from(overrides) }
   let(:site) { Jekyll::Site.new config }
   subject { described_class.new(site) }
+  before { stub_all_api_requests }
+  before { stub_api "/repos/jekyll/another-repo", "repo" }
 
   context "in Liquid" do
     before(:each) do
-      stub_all_api_requests
       site.config.delete("repository")
       site.config["github"] = subject
     end
@@ -67,6 +68,7 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
 
   context "with PAGES_REPO_NWO and site.repository set" do
     before(:each) { ENV["PAGES_REPO_NWO"] = "jekyll/some-repo" }
+    before { stub_api "/repos/jekyll/some-repo", "repo" }
 
     it "uses the value from PAGES_REPO_NWO" do
       expect(subject.send(:nwo, site)).to eql("jekyll/some-repo")

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
   let(:config) { Jekyll::Configuration.from(overrides) }
   let(:site) { Jekyll::Site.new config }
   subject { described_class.new(site) }
-  before { Jekyll::GitHubMetadata.site = site }
   before { stub_all_api_requests }
 
   context "in Liquid" do

--- a/spec/repository_finder_spec.rb
+++ b/spec/repository_finder_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe Jekyll::GitHubMetadata::RepositoryFinder do
   let(:overrides) { { "repository" => "jekyll/another-repo" } }
   let(:config) { Jekyll::Configuration.from(overrides) }
   let(:site) { Jekyll::Site.new config }
-  before { Jekyll::GitHubMetadata.site = site }
-  subject { described_class }
+  subject { described_class.new(site) }
 
   context "with no repository set" do
     before(:each) do

--- a/spec/repository_finder_spec.rb
+++ b/spec/repository_finder_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+RSpec.describe Jekyll::GitHubMetadata::RepositoryFinder do
+  let(:overrides) { { "repository" => "jekyll/another-repo" } }
+  let(:config) { Jekyll::Configuration.from(overrides) }
+  let(:site) { Jekyll::Site.new config }
+  before { Jekyll::GitHubMetadata.site = site }
+  subject { described_class }
+
+  context "with no repository set" do
+    before(:each) do
+      site.config.delete("repository")
+      ENV["PAGES_REPO_NWO"] = nil
+    end
+
+    context "without a git nwo" do
+      it "raises a NoRepositoryError" do
+        allow(subject).to receive(:git_remote_url).and_return("")
+        expect(lambda do
+          subject.send(:nwo)
+        end).to raise_error(Jekyll::GitHubMetadata::NoRepositoryError)
+      end
+    end
+
+    it "retrieves the git remote" do
+      allow(subject).to receive(:git_remote_url).and_call_original
+      expect(subject.send(:git_remote_url)).to include("jekyll/github-metadata")
+    end
+
+    {
+      :https => "https://github.com/foo/bar",
+      :ssh   => "git@github.com:foo/bar.git",
+    }.each do |type, url|
+      context "with a #{type} git URL" do
+        before(:each) do
+          site.config.delete("repository")
+          ENV["PAGES_REPO_NWO"] = nil
+          ENV.delete("JEKYLL_ENV")
+        end
+        after(:each) { ENV["JEKYLL_ENV"] = "test" }
+
+        it "parses the name with owner from the git URL" do
+          allow(subject).to receive(:git_remote_url).and_return(url)
+          expect(subject.send(:nwo)).to eql("foo/bar")
+        end
+      end
+    end
+  end
+
+  context "with PAGES_REPO_NWO and site.repository set" do
+    before(:each) { ENV["PAGES_REPO_NWO"] = "jekyll/some-repo" }
+
+    it "uses the value from PAGES_REPO_NWO" do
+      expect(subject.send(:nwo)).to eql("jekyll/some-repo")
+    end
+  end
+
+  context "with only site.repository set" do
+    before(:each) { ENV["PAGES_REPO_NWO"] = nil }
+
+    it "uses the value from site.repository" do
+      expect(subject.send(:nwo)).to eql("jekyll/another-repo")
+    end
+  end
+
+  context "when determining the nwo via git" do
+    before(:each) { ENV.delete("JEKYLL_ENV") }
+    after(:each) { ENV["JEKYLL_ENV"] = "test" }
+
+    it "handles periods in repo names" do
+      allow(subject).to receive(:git_remote_url).and_return <<-EOS
+  origin  https://github.com/afeld/hackerhours.org.git (fetch)
+  origin  https://github.com/afeld/hackerhours.org.git (push)
+  EOS
+      expect(subject.send(:nwo_from_git_origin_remote)).to include("afeld/hackerhours.org")
+    end
+
+    context "when git doesn't exist" do
+      before(:each) { @old_path = ENV.delete("PATH").to_s.split(File::PATH_SEPARATOR) }
+      after(:each)  { ENV["PATH"] = @old_path.join(File::PATH_SEPARATOR) }
+
+      it "fails with a nice error message" do
+        allow(subject).to receive(:git_remote_url).and_call_original
+        expect(subject.send(:git_exe_path)).to eql(nil)
+        expect(subject.send(:git_remote_url)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
   let(:user_config) { {} }
   let(:site) { Jekyll::Site.new(Jekyll::Configuration.from(user_config)) }
   subject { described_class.new(site) }
+  before { stub_all_api_requests }
+  before { stub_api "/repos/jekyll/another-repo", "repo" }
 
   context "generating" do
-    let!(:stubs) { stub_all_api_requests }
     before(:each) do
       ENV["JEKYLL_ENV"] = "production"
       subject.munge!
@@ -82,6 +83,10 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
   context "with a client with no credentials" do
     before(:each) do
       Jekyll::GitHubMetadata.client = Jekyll::GitHubMetadata::Client.new({ :access_token => "" })
+    end
+    before do
+      headers = { "Authorization"=>"token" }
+      stub_api "/repos/jekyll/github-metadata", "repo", headers
     end
 
     it "does not fail upon call to #munge" do

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
       let(:user_config) { { "baseurl" => "/foo" } }
 
       it "doesn't mangle site.url" do
-        expect(site.config["baseurl"].to_s).to eql("/foo")
+        expect(site.config["baseurl"]).to eql("/foo")
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
       let(:user_config) { { "baseurl" => "" } }
 
       it "doesn't mangle site.baseurl" do
-        expect(site.config["baseurl"].to_s).to eql("")
+        expect(site.config["baseurl"]).to eql("")
       end
     end
 
@@ -44,19 +44,19 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
       let(:user_config) { { "baseurl" => "/" } }
 
       it "mangles site.url" do
-        expect(site.config["baseurl"].to_s).to eql("/github-metadata")
+        expect(site.config["baseurl"]).to eql("/github-metadata")
       end
     end
 
     context "without site.url set" do
       it "sets site.url" do
-        expect(site.config["url"].to_s).to eql("http://jekyll.github.io")
+        expect(site.config["url"]).to eql("http://jekyll.github.io")
       end
     end
 
     context "without site.baseurl set" do
       it "sets site.baseurl" do
-        expect(site.config["baseurl"].to_s).to eql("/github-metadata")
+        expect(site.config["baseurl"]).to eql("/github-metadata")
       end
     end
 
@@ -67,14 +67,14 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
         end
 
         it "respects the title and tagline" do
-          expect(site.config["title"].to_s).to eql("My title")
-          expect(site.config["description"].to_s).to eql("My description")
+          expect(site.config["title"]).to eql("My title")
+          expect(site.config["description"]).to eql("My description")
         end
       end
 
       it "sets the title and description" do
-        expect(site.config["title"].to_s).to eql("github-metadata")
-        expect(site.config["description"].to_s).to eql(":octocat: `site.github`")
+        expect(site.config["title"]).to eql("github-metadata")
+        expect(site.config["description"]).to eql(":octocat: `site.github`")
       end
     end
   end

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
       let(:user_config) { { "baseurl" => "/foo" } }
 
       it "doesn't mangle site.url" do
-        expect(site.config["baseurl"]).to eql("/foo")
+        expect(site.config["baseurl"].to_s).to eql("/foo")
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
       let(:user_config) { { "baseurl" => "" } }
 
       it "doesn't mangle site.baseurl" do
-        expect(site.config["baseurl"]).to eql("")
+        expect(site.config["baseurl"].to_s).to eql("")
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
       let(:user_config) { { "baseurl" => "/" } }
 
       it "mangles site.url" do
-        expect(site.config["baseurl"]).to eql("/github-metadata")
+        expect(site.config["baseurl"].to_s).to eql("/github-metadata")
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
 
     context "without site.baseurl set" do
       it "sets site.baseurl" do
-        expect(site.config["baseurl"]).to eql("/github-metadata")
+        expect(site.config["baseurl"].to_s).to eql("/github-metadata")
       end
     end
 

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
     it "fails loudly upon call to any drop method" do
       subject.munge!
       expect(lambda do
+        site.config["github"]["url"]
       end).to raise_error(Jekyll::GitHubMetadata::Client::BadCredentialsError)
     end
   end

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -8,10 +8,9 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
   let(:user_config) { {} }
   let(:site) { Jekyll::Site.new(Jekyll::Configuration.from(user_config)) }
   subject { described_class.new(site) }
-  before { stub_all_api_requests }
-  before { stub_api "/repos/jekyll/another-repo", "repo" }
 
   context "generating" do
+    let!(:stubs) { stub_all_api_requests }
     before(:each) do
       ENV["JEKYLL_ENV"] = "production"
       subject.munge!
@@ -51,7 +50,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
 
     context "without site.url set" do
       it "sets site.url" do
-        expect(site.config["url"]).to eql("http://jekyll.github.io")
+        expect(site.config["url"].to_s).to eql("http://jekyll.github.io")
       end
     end
 
@@ -68,14 +67,14 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
         end
 
         it "respects the title and tagline" do
-          expect(site.config["title"]).to eql("My title")
-          expect(site.config["description"]).to eql("My description")
+          expect(site.config["title"].to_s).to eql("My title")
+          expect(site.config["description"].to_s).to eql("My description")
         end
       end
 
       it "sets the title and description" do
-        expect(site.config["title"]).to eql("github-metadata")
-        expect(site.config["description"]).to eql(":octocat: `site.github`")
+        expect(site.config["title"].to_s).to eql("github-metadata")
+        expect(site.config["description"].to_s).to eql(":octocat: `site.github`")
       end
     end
   end
@@ -83,10 +82,6 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
   context "with a client with no credentials" do
     before(:each) do
       Jekyll::GitHubMetadata.client = Jekyll::GitHubMetadata::Client.new({ :access_token => "" })
-    end
-    before do
-      headers = { "Authorization"=>"token" }
-      stub_api "/repos/jekyll/github-metadata", "repo", headers
     end
 
     it "does not fail upon call to #munge" do

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
     let!(:stubs) { stub_all_api_requests }
     before(:each) do
       ENV["JEKYLL_ENV"] = "production"
-      Jekyll::GitHubMetadata.instance_variable_set "@repository", nil
       subject.munge!
     end
 

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
     let!(:stubs) { stub_all_api_requests }
     before(:each) do
       ENV["JEKYLL_ENV"] = "production"
+      Jekyll::GitHubMetadata.instance_variable_set "@repository", nil
       subject.munge!
     end
 
@@ -113,7 +114,7 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
     it "fails loudly upon call to any drop method" do
       subject.munge!
       expect(lambda do
-        site.config["github"]["url"]
+        puts site.config["github"]["url"].inspect
       end).to raise_error(Jekyll::GitHubMetadata::Client::BadCredentialsError)
     end
   end

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
     it "fails loudly upon call to any drop method" do
       subject.munge!
       expect(lambda do
-        puts site.config["github"]["url"].inspect
       end).to raise_error(Jekyll::GitHubMetadata::Client::BadCredentialsError)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "jekyll-github-metadata"
 require "webmock/rspec"
 require "pathname"
+require "jekyll"
 
 SPEC_DIR = Pathname.new(File.expand_path("../", __FILE__))
 
@@ -110,6 +111,44 @@ module EnvHelper
     end
     raise ArgumentError, "Expect 2 strings or a Hash of VAR => VAL"
   end
+end
+
+def expected_values
+  {
+    "environment"          => "dotcom",
+    "hostname"             => "github.com",
+    "pages_env"            => "dotcom",
+    "pages_hostname"       => "github.io",
+    "help_url"             => "https://help.github.com",
+    "api_url"              => "https://api.github.com",
+    "versions"             => {},
+    "public_repositories"  => Regexp.new('"id"=>17261694, "name"=>"atom-jekyll"'),
+    "organization_members" => Regexp.new('"login"=>"parkr", "id"=>237985'),
+    "build_revision"       => %r![a-f0-9]{40}!,
+    "project_title"        => "github-metadata",
+    "project_tagline"      => ":octocat: `site.github`",
+    "owner_name"           => "jekyll",
+    "owner_url"            => "https://github.com/jekyll",
+    "owner_gravatar_url"   => "https://github.com/jekyll.png",
+    "repository_url"       => "https://github.com/jekyll/github-metadata",
+    "repository_nwo"       => "jekyll/github-metadata",
+    "repository_name"      => "github-metadata",
+    "zip_url"              => "https://github.com/jekyll/github-metadata/zipball/gh-pages",
+    "tar_url"              => "https://github.com/jekyll/github-metadata/tarball/gh-pages",
+    "clone_url"            => "https://github.com/jekyll/github-metadata.git",
+    "releases_url"         => "https://github.com/jekyll/github-metadata/releases",
+    "issues_url"           => "https://github.com/jekyll/github-metadata/issues",
+    "wiki_url"             => nil, # disabled
+    "language"             => "Ruby",
+    "is_user_page"         => false,
+    "is_project_page"      => true,
+    "show_downloads"       => true,
+    "url"                  => "http://jekyll.github.io/github-metadata",
+    "baseurl"              => "/github-metadata",
+    "contributors"         => %r!"login"=>"parkr", "id"=>237985!,
+    "releases"             => %r!"tag_name"=>"v1.1.0"!,
+    "latest_release"       => %r!assets_url!,
+  }
 end
 
 RSpec.configure do |config|

--- a/spec/test-site/index.html
+++ b/spec/test-site/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <div id="output"></div>
-    <script src="renderjson.js" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ "renderjson.js" | absolute_url }}" type="text/javascript" charset="utf-8"></script>
     <script>
     var site = {{ site.github | jsonify }};
     document.getElementById("output").appendChild(renderjson.set_show_to_level(2)(site));

--- a/spec/value_spec.rb
+++ b/spec/value_spec.rb
@@ -67,4 +67,26 @@ RSpec.describe(Jekyll::GitHubMetadata::Value) do
     expect(key_and_value.key).to eql("my_key2")
     expect(key_and_value.render).to eql("leonard told me")
   end
+
+  context "delegators" do
+    it "delegates +" do
+      expect(key_and_value + " foo").to eql("leonard told me foo")
+    end
+
+    it "delegates to_s" do
+      expect(number_value.to_s).to eql("4")
+    end
+
+    it "delegates to_json" do
+      expect(key_and_value.to_json).to eql('"leonard told me"')
+    end
+
+    it "delegates eql?" do
+      expect(key_and_value).to eql("leonard told me")
+    end
+
+    it "delegates hash" do
+      expect(key_and_value.hash).to eql("leonard told me".hash)
+    end
+  end
 end


### PR DESCRIPTION
A follow up to https://github.com/jekyll/github-metadata/pull/101, the title and description were only being set in production, making local previewing difficult.

This PR updates the logic to set the title and description in dev by moving the conditional statement.