### PR TITLE
Expose repo visibility

### DIFF
--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -74,6 +74,7 @@ module Jekyll
       def_delegator :repository, :contributors,                :contributors
       def_delegator :repository, :releases,                    :releases
       def_delegator :repository, :latest_release,              :latest_release
+      def_delegator :repository, :private?,                    :private
 
       private
       attr_reader :site

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -80,6 +80,10 @@ module Jekyll
         !!repo_info["has_downloads"]
       end
 
+      def private?
+        !!repo_info["private"]
+      end
+
       def organization_repository?
         memoize_value :@is_organization_repository, Value.new(proc { |c| !!c.organization(owner) })
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe("integration into a jekyll site") do
     "baseurl"              => "/github-metadata",
     "contributors"         => %r!"login"=>"parkr", "id"=>237985!,
     "releases"             => %r!"tag_name"=>"v1.1.0"!,
+    "private"              => false,
   }.each do |key, value|
     it "contains the correct #{key}" do
       expect(subject).to have_key(key)


### PR DESCRIPTION
This PR adds a `private` key to the `site.github` namespace. The value will be `true` if the repo is private, otherwise, it will be `false`. This will allow a site to know it's visibility (for example, to conditionally expose an edit button via a theme).