### PR TITLE
Allow user values to override drop-determined values

### DIFF
--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -70,7 +70,7 @@ module Jekyll
 
       def repository
         @repository ||= GitHubMetadata::Repository.new(repository_finder.nwo).tap do |repo|
-          Jekyll::GitHubMetadata.log :debug, "Generating for #{repo.nwo}"
+          log :debug, "Generating for #{repo.nwo}"
         end
       end
 

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -8,6 +8,9 @@ module Jekyll
 
       mutable true
 
+      # See https://github.com/jekyll/jekyll/pull/6338
+      alias_method :invoke_drop, :[]
+
       def to_s
         require "json"
         JSON.pretty_generate to_h

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -10,6 +10,13 @@ module Jekyll
 
       # See https://github.com/jekyll/jekyll/pull/6338
       alias_method :invoke_drop, :[]
+      def key?(key)
+        if self.class.mutable?
+          @mutations.key?(key)
+        else
+          !key.nil? && (respond_to?(key) || fallback_data.key?(key))
+        end
+      end
 
       def to_s
         require "json"

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -30,7 +30,7 @@ module Jekyll
         when nil
           drop
         when Hash
-          Jekyll::Utils.deep_merge_hashes(site.config["github"], drop)
+          Jekyll::Utils.deep_merge_hashes(drop, site.config["github"])
         else
           site.config["github"]
         end

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -66,5 +66,5 @@ module Jekyll
 end
 
 Jekyll::Hooks.register :site, :after_init do |site|
-  Jekyll::GitHubMetadata::SiteGitHubMunger.new(site).munge! unless Jekyll.env == "test"
+  Jekyll::GitHubMetadata::SiteGitHubMunger.new(site).munge!
 end

--- a/spec/edit_link_tag_spec.rb
+++ b/spec/edit_link_tag_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe Jekyll::GitHubMetadata::EditLinkTag do
     tag
   end
 
-  before do
-    Jekyll.logger.log_level = :error
-  end
-
   it "knows the page" do
     expect(subject.send(:page)).to be_a(Jekyll::Page)
   end

--- a/spec/edit_link_tag_spec.rb
+++ b/spec/edit_link_tag_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Jekyll::GitHubMetadata::EditLinkTag do
   let(:path) { "/" }
   let(:source) { { "branch" => branch, "path" => path } }
   let(:github) { { "repository_url" => repository_url, "source" => source } }
-  let(:config) { { "github" => github } }
+  let(:config) { { "github" => github, "plugins" => ["jekyll-github-metadata"] } }
   let(:page) { make_page }
   let(:site) { make_site(config) }
   let(:render_context) { make_context(:page => page, :site => site) }
@@ -64,6 +64,14 @@ RSpec.describe Jekyll::GitHubMetadata::EditLinkTag do
 
       it "builds the URL" do
         expect(uri).to eql("#{repository_url}/edit/gh-pages/page.md")
+      end
+    end
+
+    context "an arbitrary branch" do
+      let(:branch) { "foo" }
+
+      it "builds the URL" do
+        expect(uri).to eql("#{repository_url}/edit/foo/page.md")
       end
     end
   end

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
       let(:github_namespace) { { "source" => { "branch" => "foo" } } }
 
       it "lets user-specified values override the drop" do
-        expect(site.config["github"]["source"]["branch"]).to eql("foo")
+        expect(site.config["github"].invoke_drop("source")["branch"]).to eql("foo")
       end
 
       it "still sets other values" do
-        expect(site.config["github"]["source"]["path"]).to eql("/")
+        expect(site.config["github"].invoke_drop("source")["path"]).to eql("/")
       end
     end
 

--- a/spec/site_github_munger_spec.rb
+++ b/spec/site_github_munger_spec.rb
@@ -5,7 +5,8 @@ require "jekyll-github-metadata/site_github_munger"
 RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
   let(:source) { File.expand_path("test-site", __dir__) }
   let(:dest) { File.expand_path("../tmp/test-site-build", __dir__) }
-  let(:user_config) { {} }
+  let(:github_namespace) { nil }
+  let(:user_config) { { "github" => github_namespace } }
   let(:site) { Jekyll::Site.new(Jekyll::Configuration.from(user_config)) }
   subject { described_class.new(site) }
   let!(:stubs) { stub_all_api_requests }
@@ -14,6 +15,40 @@ RSpec.describe(Jekyll::GitHubMetadata::SiteGitHubMunger) do
     before(:each) do
       ENV["JEKYLL_ENV"] = "production"
       subject.munge!
+    end
+
+    context "with site.github as nil" do
+      it "replaces site.github with the drop" do
+        expect(site.config["github"]).to be_a(Liquid::Drop)
+      end
+    end
+
+    context "without site.github" do
+      let(:user_config) { {} }
+
+      it "replaces site.github with the drop" do
+        expect(site.config["github"]).to be_a(Liquid::Drop)
+      end
+    end
+
+    context "with site.github as a non-hash" do
+      let(:github_namespace) { "foo" }
+
+      it "doesn't munge" do
+        expect(site.config["github"]).to eql("foo")
+      end
+    end
+
+    context "with site.github as a hash" do
+      let(:github_namespace) { { "source" => { "branch" => "foo" } } }
+
+      it "lets user-specified values override the drop" do
+        expect(site.config["github"]["source"]["branch"]).to eql("foo")
+      end
+
+      it "still sets other values" do
+        expect(site.config["github"]["source"]["path"]).to eql("/")
+      end
     end
 
     context "with site.url set" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
+require "jekyll"
 require "jekyll-github-metadata"
 require "webmock/rspec"
 require "pathname"
-require "jekyll"
 
 require_relative "spec_helpers/env_helper"
 require_relative "spec_helpers/integration_helper"


### PR DESCRIPTION
Via https://github.com/jekyll/github-metadata/pull/108#issuecomment-325817689, it appears user-supplied `site.github` values are being overwritten by drop-supplied values.

It appears in https://github.com/jekyll/github-metadata/commit/54942a488f493a346d709c208799558afc012a5a#diff-165b64b2f6bce98447b6c550f3205ad9L26, the order of the arguements passed to `Jekyll::Utils.deep_merge_hashes` were reversed since [the right overrides the left value](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/utils.rb#L39-L54).

This PR adds failing tests via a7d2b4b to ensure `site.github` is set to the expected value given different user-supplied inputs for `site.github` with d36d1af reversing the order of the arguments.

/cc @DirtyF 
