### PR TITLE
Mutable drops should fallback to their own methods when a mutation isn't present

### DIFF
--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -11,11 +11,8 @@ module Jekyll
       # See https://github.com/jekyll/jekyll/pull/6338
       alias_method :invoke_drop, :[]
       def key?(key)
-        if self.class.mutable?
-          @mutations.key?(key)
-        else
-          !key.nil? && (respond_to?(key) || fallback_data.key?(key))
-        end
+        return false if key.nil?
+        @mutations.key?(key) || respond_to?(key) || fallback_data.key?(key)
       end
 
       def to_s

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -12,7 +12,8 @@ module Jekyll
       alias_method :invoke_drop, :[]
       def key?(key)
         return false if key.nil?
-        @mutations.key?(key) || respond_to?(key) || fallback_data.key?(key)
+        return true if self.class.mutable? && @mutations.key?(key)
+        respond_to?(key) || fallback_data.key?(key)
       end
 
       def to_s

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -50,4 +50,53 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
       expect(payload.keys).to match_array(expected_values.keys)
     end
   end
+
+  context "returning values" do
+    context "native methods" do
+      it "returns a value via #[]" do
+        expect(subject["url"]).to eql("http://jekyll.github.io/github-metadata")
+      end
+
+      it "returns a value via #invoke_drop" do
+        expect(subject.invoke_drop("url")).to eql("http://jekyll.github.io/github-metadata")
+      end
+
+      it "responds to #key?" do
+        expect(subject.key?("url")).to be_truthy
+      end
+    end
+
+    context "with mutated values" do
+      before { subject["url"] = "foo" }
+
+      it "returns the mutated value via #[]" do
+        expect(subject["url"]).to eql("foo")
+      end
+
+      it "returns the mutated  via #invoke_drop" do
+        expect(subject.invoke_drop("url")).to eql("foo")
+      end
+
+      it "responds to #key?" do
+        expect(subject.key?("url")).to be_truthy
+      end
+    end
+
+    context "with fallback data" do
+      let(:fallback_data) { { "foo" => "bar" } }
+      before { subject.instance_variable_set("@fallback_data", fallback_data) }
+
+      it "returns the mutated value via #[]" do
+        expect(subject["foo"]).to eql("bar")
+      end
+
+      it "returns the mutated  via #invoke_drop" do
+        expect(subject.invoke_drop("foo")).to eql("bar")
+      end
+
+      it "responds to #key?" do
+        expect(subject.key?("foo")).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a side effect of monkey patching https://github.com/jekyll/jekyll/pull/6338 into https://github.com/jekyll/github-metadata/pull/110.

In https://github.com/jekyll/jekyll/pull/6338 the problem was that `Drop#key?` needed to call `self.class.mutable?` not `self.class.mutable`. Rather than wait on the upstream fix, I monkey patched a modified version of `key?` with that single character change. 

As it turns out, there's more wrong with `key?` in Jekyll core. If you read through the logic of:

https://github.com/jekyll/jekyll/blob/8b47fb1f7a85d518a21f5fcfd3b20df18c60bf7a/lib/jekyll/drops/drop.rb#L101-L112

You'll see that if a Drop is mutable, and the user hasn't overridden the requested key, the Drop will respond that it doesn't know anything about the key (even if it has a non-mutated native method that's the intended value).

In this case, if a user, for example, calls `site.github.url`, it'd work fine if they overrode the value, but Liquid, which calls `Drop#key?` would assume the drop didn't respond to the key since the Drop only looked at mutations.

This PR adds tests for the temporarily monkey-patched methods, and corrects the logic of `Drop#key?` to look for a corresponding key in the mutable data, in its own methods, and then in the fallback data, responding true if a key exists in any (meaning the Drop could respond to the requested key).

/cc @parkr 