### PR TITLE
Add script/console to help debug

### DIFF
--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "netrc"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rubocop", "0.51"
 end

--- a/script/console
+++ b/script/console
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+PAGES_ENV=dotcom PAGES_PREVIEW_HTML_URL=true bundle exec ruby script/console.rb

--- a/script/console.rb
+++ b/script/console.rb
@@ -1,0 +1,15 @@
+require 'octokit'
+require 'pry'
+
+stack = Faraday::RackBuilder.new do |builder|
+  builder.use Octokit::Middleware::FollowRedirects
+  builder.use Octokit::Response::RaiseError
+  builder.use Octokit::Response::FeedParser
+  builder.response :logger
+  builder.adapter Faraday.default_adapter
+end
+Octokit.middleware = stack
+
+require_relative "../lib/jekyll-github-metadata"
+
+binding.pry


### PR DESCRIPTION
`script/console` will open a PRY session with Octokit debug output enabled and pseudo-production values as the default to help diagnose failed builds.