### PR TITLE
update GitHub Pages domain suffix to github.io

### DIFF
--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -147,7 +147,7 @@ module Jekyll
 
       def user_page_domains
         domains = [default_user_domain]
-        domains.push "#{owner}.github.com".downcase unless Pages.enterprise?
+        domains.push "#{owner}.github.io".downcase unless Pages.enterprise?
         domains
       end
 


### PR DESCRIPTION
Since GitHub has moved from .com to .io to host gh-pages, https://blog.github.com/2013-04-05-new-github-pages-domain-github-io/
It makes sense to update here as well.