### PR TITLE
Make github.com repo URLs always https

### DIFF
--- a/lib/jekyll-github-metadata/pages.rb
+++ b/lib/jekyll-github-metadata/pages.rb
@@ -53,7 +53,7 @@ module Jekyll
         end
 
         def github_url
-          if dotcom?
+          if dotcom? || github_hostname == "github.com"
             "https://github.com".freeze
           else
             "#{scheme}://#{github_hostname}"

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -158,5 +158,27 @@ RSpec.describe(Jekyll::GitHubMetadata::Repository) do
         end
       end
     end
+    
+    context "in development" do
+      let(:nwo) { "jekyll/jekyll" }
+      
+      it "github.com repo URL always https" do
+        with_env({
+          "GITHUB_HOSTNAME" => "github.com",
+          "PAGES_ENV"       => "development"
+        }) do
+          expect(repo.repository_url).to eql("https://github.com/#{nwo}")
+        end
+      end
+      
+      it "non-github.com repo URL always http" do
+        with_env({
+          "GITHUB_HOSTNAME" => "xyz.example",
+          "PAGES_ENV"       => "development"
+        }) do
+          expect(repo.repository_url).to eql("http://xyz.example/#{nwo}")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
In development mode (the default) github.com repo URLs are http,
making sites using edit-link-tag have slightly different builds in
development than on github pages (dotcom) which are also slightly
harder to test for all links being https, eg using html-proofer
with its enforce_https option, and making builds published to
non-github pages hosts have non-https links to github.com.

Trivial patch for a very mild annoyance.

The added test is somewhat contrived, because existing tests don't
trigger the behavior, running in test mode (which defaults scheme
to ssl), or hardcoding the repository url (in the edit-link-tag
test).