### PR TITLE
Fixes for repository detection on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.5
   - 2.4
   - 2.3
-  - 2.2
 env:
   matrix:
     - JEKYLL_VERSION=3.5

--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(%r!^(lib|bin)/!)
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.1"
+  spec.add_runtime_dependency "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : "~> 3.4"
   spec.add_runtime_dependency "octokit", "~> 4.0", "!= 4.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -48,7 +48,7 @@ module Jekyll
       end
 
       def git_exe_path
-        exts = (ENV['PATHEXT'] || '').split(File::PATH_SEPARATOR)
+        exts = (ENV['PATHEXT'] || '').split(File::PATH_SEPARATOR).push('')
         cmds = exts.map { |ext| "git#{ext}" }
         ENV["PATH"].to_s
           .split(File::PATH_SEPARATOR)

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -46,13 +46,11 @@ module Jekyll
       end
 
       def git_remotes
-        output = ""
-        begin
-          _process, output = Jekyll::Utils::Exec.run("git", "remote", "--verbose")
-        rescue Errno::ENOENT => e
-          Jekyll.logger.warn "Not Installed:", e.message
-        end
+        _process, output = Jekyll::Utils::Exec.run("git", "remote", "--verbose")
         output.to_s.strip.split("\n")
+      rescue Errno::ENOENT => e
+        Jekyll.logger.warn "Not Installed:", e.message
+        ""
       end
 
       def git_remote_url

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -47,19 +47,13 @@ module Jekyll
         repo if repo && repo.is_a?(String) && repo.include?("/")
       end
 
-      def git_exe_path
-        exts = (ENV["PATHEXT"] || "").split(File::PATH_SEPARATOR).push("")
-        cmds = exts.map { |ext| "git#{ext}" }
-        ENV["PATH"].to_s
-          .split(File::PATH_SEPARATOR)
-          .map { |path| cmds.map { |cmd| File.join(path, cmd) } }
-          .flatten
-          .find { |path| File.executable?(path) && !File.directory?(path) }
-      end
-
       def git_remotes
-        return [] if git_exe_path.nil?
-        output, _status = Open3.capture2(git_exe_path, "remote", "--verbose")
+        output = ""
+        begin
+          _p, output = Jekyll::Utils::Exec.run("git", "remote", "--verbose")
+        rescue Errno::ENOENT => e
+          Jekyll.logger.warn "Git is not installed: ", e.message
+        end
         output.to_s.strip.split("\n")
       end
 

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -50,7 +50,7 @@ module Jekyll
         begin
           _process, output = Jekyll::Utils::Exec.run("git", "remote", "--verbose")
         rescue Errno::ENOENT => e
-          Jekyll.logger.warn "Git is not installed: ", e.message
+          Jekyll.logger.warn "Not Installed:", e.message
         end
         output.to_s.strip.split("\n")
       end

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'open3'
+require "open3"
 
 module Jekyll
   module GitHubMetadata
@@ -48,7 +48,7 @@ module Jekyll
       end
 
       def git_exe_path
-        exts = (ENV['PATHEXT'] || '').split(File::PATH_SEPARATOR).push('')
+        exts = (ENV["PATHEXT"] || "").split(File::PATH_SEPARATOR).push("")
         cmds = exts.map { |ext| "git#{ext}" }
         ENV["PATH"].to_s
           .split(File::PATH_SEPARATOR)
@@ -59,7 +59,7 @@ module Jekyll
 
       def git_remotes
         return [] if git_exe_path.nil?
-        output, status = Open3.capture2(git_exe_path, 'remote', '--verbose')
+        output, _status = Open3.capture2(git_exe_path, "remote", "--verbose")
         output.to_s.strip.split("\n")
       end
 

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -46,10 +46,13 @@ module Jekyll
       end
 
       def git_exe_path
+        exts = (ENV['PATHEXT'] || '').split(File::PATH_SEPARATOR)
+        cmds = exts.map { |ext| "git#{ext}" }
         ENV["PATH"].to_s
           .split(File::PATH_SEPARATOR)
-          .map { |path| File.join(path, "git") }
-          .find { |path| File.exist?(path) }
+          .map { |path| cmds.map { |cmd| File.join(path, cmd) } }
+          .flatten
+          .find { |path| File.executable?(path) && !File.directory?(path) }
       end
 
       def git_remotes

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -50,7 +50,7 @@ module Jekyll
         output.to_s.strip.split("\n")
       rescue Errno::ENOENT => e
         Jekyll.logger.warn "Not Installed:", e.message
-        ""
+        []
       end
 
       def git_remote_url

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -48,7 +48,7 @@ module Jekyll
       def git_remotes
         output = ""
         begin
-          _p, output = Jekyll::Utils::Exec.run("git", "remote", "--verbose")
+          _process, output = Jekyll::Utils::Exec.run("git", "remote", "--verbose")
         rescue Errno::ENOENT => e
           Jekyll.logger.warn "Git is not installed: ", e.message
         end

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 module Jekyll
   module GitHubMetadata
     class RepositoryFinder
@@ -57,7 +59,8 @@ module Jekyll
 
       def git_remotes
         return [] if git_exe_path.nil?
-        `#{git_exe_path} remote --verbose`.to_s.strip.split("\n")
+        output, status = Open3.capture2(git_exe_path, 'remote', '--verbose')
+        output.to_s.strip.split("\n")
       end
 
       def git_remote_url

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "open3"
-
 module Jekyll
   module GitHubMetadata
     class RepositoryFinder

--- a/spec/repository_finder_spec.rb
+++ b/spec/repository_finder_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Jekyll::GitHubMetadata::RepositoryFinder do
 
       it "fails with a nice error message" do
         allow(subject).to receive(:git_remote_url).and_call_original
-        expect(subject.send(:git_exe_path)).to eql(nil)
         expect(subject.send(:git_remote_url)).to be_empty
       end
     end

--- a/spec/repository_finder_spec.rb
+++ b/spec/repository_finder_spec.rb
@@ -77,8 +77,11 @@ RSpec.describe Jekyll::GitHubMetadata::RepositoryFinder do
     end
 
     context "when git doesn't exist" do
-      before(:each) { @old_path = ENV.delete("PATH").to_s.split(File::PATH_SEPARATOR) }
-      after(:each)  { ENV["PATH"] = @old_path.join(File::PATH_SEPARATOR) }
+      before(:each) do
+        @old_path = ENV["PATH"]
+        ENV["PATH"] = ""
+      end
+      after(:each)  { ENV["PATH"] = @old_path }
 
       it "fails with a nice error message" do
         allow(subject).to receive(:git_remote_url).and_call_original


### PR DESCRIPTION
The repository detection code wasn't portable to Windows.

These changes fix detection on Windows and maintain portability with other platforms.