### PR TITLE
Remove redundant code

### DIFF
--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -44,11 +44,7 @@ module Jekyll
       end
 
       def logger
-        @logger ||= if Jekyll.respond_to?(:logger)
-                      Jekyll.logger
-                    else
-                      Logger.new($stdout)
-                    end
+        @logger ||= Jekyll.logger
       end
 
       def log(severity, message)

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
+require "jekyll"
 require "octokit"
-require "liquid"
-require "logger"
 
-if defined?(Jekyll) && Jekyll.respond_to?(:env) && Jekyll.env == "development"
+if Jekyll.respond_to?(:env) && Jekyll.env == "development"
   begin
     require "dotenv"
     Dotenv.load

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -3,7 +3,7 @@
 require "jekyll"
 require "octokit"
 
-if Jekyll.respond_to?(:env) && Jekyll.env == "development"
+if Jekyll.env == "development"
   begin
     require "dotenv"
     Dotenv.load
@@ -46,7 +46,7 @@ module Jekyll
       end
 
       def environment
-        Jekyll.respond_to?(:env) ? Jekyll.env : (Pages.env || "development")
+        Jekyll.env
       end
 
       def logger

--- a/lib/jekyll-github-metadata.rb
+++ b/lib/jekyll-github-metadata.rb
@@ -13,12 +13,6 @@ if Jekyll.env == "development"
 end
 
 module Jekyll
-  unless const_defined? :Errors
-    module Errors
-      FatalException = Class.new(::RuntimeError) unless const_defined? :FatalException
-    end
-  end
-
   module GitHubMetadata
     autoload :Client,           "jekyll-github-metadata/client"
     autoload :EditLinkTag,      "jekyll-github-metadata/edit-link-tag"


### PR DESCRIPTION
Some of the checks placed here were to support Jekyll 2.x and is no longer necessary since we're requiring `Jekyll 3.1+` now

Not sure why the following has a check since Jekyll has always had `Site` constant defined.. So leaving that as is..
https://github.com/jekyll/github-metadata/blob/2c350b2fea29ee5fe18243ff84040a755a9de508/lib/jekyll-github-metadata.rb#L37-L39