### PR TITLE
Constant accessors for def_delegation

### DIFF
--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -32,14 +32,14 @@ module Jekyll
         super.sort
       end
 
-      def_delegator :"Jekyll::GitHubMetadata::Pages", :env, :environment
-      def_delegator :"Jekyll::GitHubMetadata::Pages", :env, :pages_env
-      def_delegator :"Jekyll::GitHubMetadata::Pages", :github_hostname, :hostname
-      def_delegator :"Jekyll::GitHubMetadata::Pages", :pages_hostname, :pages_hostname
-      def_delegator :"Jekyll::GitHubMetadata::Pages", :api_url, :api_url
-      def_delegator :"Jekyll::GitHubMetadata::Pages", :help_url, :help_url
+      def_delegator Jekyll::GitHubMetadata::Pages, :env,             :environment
+      def_delegator Jekyll::GitHubMetadata::Pages, :env,             :pages_env
+      def_delegator Jekyll::GitHubMetadata::Pages, :github_hostname, :hostname
+      def_delegator Jekyll::GitHubMetadata::Pages, :pages_hostname,  :pages_hostname
+      def_delegator Jekyll::GitHubMetadata::Pages, :api_url,         :api_url
+      def_delegator Jekyll::GitHubMetadata::Pages, :help_url,        :help_url
 
-      private def_delegator :"Jekyll::GitHubMetadata", :repository
+      private def_delegator Jekyll::GitHubMetadata, :repository
 
       def_delegator :repository, :owner_public_repositories,   :public_repositories
       def_delegator :repository, :organization_public_members, :organization_members

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -6,8 +6,8 @@ module Jekyll
     class SiteGitHubMunger
       extend Forwardable
 
-      def_delegators :"Jekyll::GitHubMetadata", :site
-      private def_delegator :"Jekyll::GitHubMetadata", :repository
+      def_delegators Jekyll::GitHubMetadata, :site, :repository
+      private :repository
 
       def initialize(site)
         Jekyll::GitHubMetadata.site = site


### PR DESCRIPTION
`def_delegator` and `def_delegators` can accept existing constants as well.
This means we need not stringify a constant name and then symbolize it..