### PR TITLE
Allow detecting repository on GitHub Enterprise

### DIFF
--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -61,8 +61,13 @@ module Jekyll
 
       def nwo_from_git_origin_remote
         return unless Jekyll.env == "development" || Jekyll.env == "test"
-        matches = git_remote_url.chomp(".git").match %r!github.com(:|/)([\w-]+)/([\w\.-]+)!
+        matches = git_remote_url.chomp(".git").match github_remote_regex
         matches[2..3].join("/") if matches
+      end
+
+      def github_remote_regex
+        github_host_regex = Regexp.escape(Jekyll::GitHubMetadata::Pages.github_hostname)
+        %r!#{github_host_regex}(:|/)([\w-]+)/([\w\.-]+)!
       end
     end
   end

--- a/spec/repository_finder_spec.rb
+++ b/spec/repository_finder_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe Jekyll::GitHubMetadata::RepositoryFinder do
       expect(subject.send(:nwo_from_git_origin_remote)).to include("afeld/hackerhours.org")
     end
 
+    it "handles private github instance addresses" do
+      allow(Jekyll::GitHubMetadata::Pages).to receive(:github_hostname).and_return "github.myorg.com"
+      allow(subject).to receive(:git_remote_url).and_return <<-EOS
+  origin  https://github.myorg.com/myorg/myrepo.git (fetch)
+  origin  https://github.myorg.com/myorg/myrepo.git (push)
+  EOS
+      expect(subject.send(:nwo_from_git_origin_remote)).to include("myorg/myrepo")
+    end
+
     context "when git doesn't exist" do
       before(:each) do
         @old_path = ENV["PATH"]


### PR DESCRIPTION
Alters the regex that extracts the org/username and repo name from the repo address based on suggestion by @benbalter, so that it can cope with repos that do not exist on github.com (e.g. GitHub Enterprise).

Adds a test for this change.

Resolves #120 