### PR TITLE
Expose User/Org information under site.github.owner

### DIFF
--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -12,6 +12,7 @@ module Jekyll
       API_CALLS = Set.new(%w(
         repository
         organization
+        user
         repository?
         pages
         contributors

--- a/lib/jekyll-github-metadata/metadata_drop.rb
+++ b/lib/jekyll-github-metadata/metadata_drop.rb
@@ -46,6 +46,7 @@ module Jekyll
       def_delegator :repository, :organization_public_members, :organization_members
       def_delegator :repository, :name,                        :project_title
       def_delegator :repository, :tagline,                     :project_tagline
+      def_delegator :repository, :owner_metadata,              :owner
       def_delegator :repository, :owner,                       :owner_name
       def_delegator :repository, :owner_url,                   :owner_url
       def_delegator :repository, :owner_gravatar_url,          :owner_gravatar_url

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -62,6 +62,10 @@ module Jekyll
         end
       end
 
+      def owner_metadata
+        memoize_value :@owner_metadata, Value.new(proc { |c| c.organization(owner) || c.user(owner) })
+      end
+
       def owner_url
         "#{Pages.github_url}/#{owner}"
       end

--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -62,8 +62,62 @@ module Jekyll
         end
       end
 
+      # Whitelisted keys for Organizations and Users
+      WHITELISTED_ORGANIZATION_KEYS = Set.new([
+        :login,
+        :id,
+        :node_id,
+        :url,
+        :avatar_url,
+        :description,
+        :name,
+        :company,
+        :blog,
+        :location,
+        :email,
+        :is_verified,
+        :has_organization_projects,
+        :has_repository_projects,
+        :public_repos,
+        :public_gists,
+        :followers,
+        :following,
+        :html_url,
+        :created_at,
+        :type,
+        :collaborators,
+      ])
+
+      WHITELISTED_USER_KEYS = Set.new([
+        :login,
+        :id,
+        :node_id,
+        :avatar_url,
+        :html_url,
+        :type,
+        :site_admin,
+        :name,
+        :company,
+        :blog,
+        :location,
+        :bio,
+        :public_repos,
+        :public_gists,
+        :followers,
+        :following,
+        :created_at,
+        :updated_at,
+      ])
+
       def owner_metadata
-        memoize_value :@owner_metadata, Value.new(proc { |c| c.organization(owner) || c.user(owner) })
+        memoize_value :@owner_metadata, Value.new(proc { |c|
+          org = c.organization(owner)
+          if org
+            org.to_h.select { |k, _| WHITELISTED_ORGANIZATION_KEYS.include? k }
+          else
+            c.user(owner).to_h.select { |k, _| WHITELISTED_USER_KEYS.include? k }
+          end
+        })
       end
 
       def owner_url

--- a/spec/spec_helpers/integration_helper.rb
+++ b/spec/spec_helpers/integration_helper.rb
@@ -15,6 +15,7 @@ module IntegrationHelper
       "build_revision"       => %r![a-f0-9]{40}!,
       "project_title"        => "github-metadata",
       "project_tagline"      => ":octocat: `site.github`",
+      "owner"                => Regexp.new('"login"=>"jekyll", "id"=>3083652'),
       "owner_name"           => "jekyll",
       "owner_url"            => "https://github.com/jekyll",
       "owner_gravatar_url"   => "https://github.com/jekyll.png",


### PR DESCRIPTION
Fixes #149.

Tested locally for a User object, captured everything I was interested in (full name, email, company, bio, ...)

/cc @parkr @benbalter 

Thanks!
Filipe
