### PR TITLE
Lessen Jekyll dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ rvm:
 matrix:
   include:
     - rvm: *latest_ruby
-      env: 
-        - JEKYLL_VERSION=3.7.0
-        - JEKYLL_VERSION=4.0.0.pre.alpha1
+      env: JEKYLL_VERSION=3.7.0
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION=4.0.0.pre.alpha1
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ rvm:
 matrix:
   include:
     - rvm: *latest_ruby
-      env: JEKYLL_VERSION=3.7.0
+      env: 
+        - JEKYLL_VERSION=3.7.0
+        - JEKYLL_VERSION=4.0.0.pre.alpha1
 branches:
   only:
     - master

--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").grep(%r!^(lib|bin)/!)
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jekyll", "~> 3.4"
+  spec.add_runtime_dependency "jekyll", ">= 3.4", "< 5.0"
   spec.add_runtime_dependency "octokit", "~> 4.0", "!= 4.4.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Allows the plugin to be used with Jekyll 3.x or 4.x (assuming tests pass)