### PR TITLE
Enable support for `topics` property

### DIFF
--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -107,7 +107,11 @@ module Jekyll
       end
 
       def owner_public_repositories
-        memoize_value :@owner_public_repositories, Value.new("owner_public_repositories", proc { |c| c.list_repos(owner, "type" => "public") })
+        options = {
+          :type   => "public",
+          :accept => "application/vnd.github.mercy-preview+json",
+        }
+        memoize_value :@owner_public_repositories, Value.new("owner_public_repositories", proc { |c| c.list_repos(owner, options) })
       end
 
       def organization_public_members

--- a/script/webmock-repopulate
+++ b/script/webmock-repopulate
@@ -5,7 +5,7 @@ set -e
 curl_me() {
   (set -x; curl \
     -H "Authorization: token $GITHUB_TOKEN" \
-    -H "Accept: application/vnd.github.v3+json" \
+    -H "Accept: application/vnd.github.${3:-v3}+json" \
     -H "Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3" \
     -H "Content-Type: application/json" \
     -H "User-Agent: Octokit Ruby Gem 4.2.0" \
@@ -18,6 +18,6 @@ curl_me "/repos/jekyll/github-metadata/contributors?per_page=100" "repo_contribu
 curl_me "/repos/jekyll/github-metadata/releases?per_page=100" "repo_releases"
 curl_me "/orgs/jekyll" "org"
 curl_me "/orgs/jekyll/public_members" "org_members"
-curl_me "/users/jekyll/repos?per_page=100&type=public" "owner_repos"
+curl_me "/users/jekyll/repos?per_page=100&type=public" "owner_repos" "mercy-preview"
 curl_me "/repos/jekyll/github-metadata/pages" "repo_pages"
 curl_me "/repos/jekyll/github-metadata/releases/latest" "latest_release"

--- a/spec/spec_helpers/web_mock_helper.rb
+++ b/spec/spec_helpers/web_mock_helper.rb
@@ -2,7 +2,7 @@
 
 module WebMockHelper
   REQUEST_HEADERS = {
-    "Accept"          => %r!application/vnd\.github\.(v3|drax-preview)\+json!,
+    "Accept"          => %r!application/vnd\.github\.(v3|drax-preview|mercy-preview)\+json!,
     "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
     "Content-Type"    => "application/json",
     "User-Agent"      => "Octokit Ruby Gem #{Octokit::VERSION}",


### PR DESCRIPTION
Include the topics property in the repository results using the `application/vnd.github.mercy-preview+json` media type.