### PR TITLE
List the fields this repo generates for site.github

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Jekyll plugin to propagate the `site.github` namespace and set default values fo
 
 ## What it does
 
-* Propagates the `site.github` namespace with [repository metadata](https://help.github.com/articles/repository-metadata-on-github-pages/)
+* Propagates the `site.github` namespace with [repository metadata](site.github.md)
 * Sets `site.title` as the repository name, if none is set
 * Sets `site.description` as the repository tagline if none is set
 * Sets `site.url` as the GitHub Pages domain (cname or user domain), if none is set
@@ -41,4 +41,5 @@ Then go ahead and run `bundle install`. Once you've done that jekyll-github-meta
 
 * [Authentication](authentication.md)
 * [Configuration](configuration.md)
+* [Using `site.github`](site.github.md)
 * [Edit on GitHub link](edit-on-github-link.md)

--- a/docs/site.github.md
+++ b/docs/site.github.md
@@ -1,0 +1,84 @@
+## Using `site.github`
+
+Common repository information, such as the project name and description, is available to Jekyll sites using `jekyll-github-metadata` including GitHub Pages sites.
+
+#### Usage
+
+Repository metadata is exposed to your Jekyll site's configuration in the `site.github` namespace.
+
+Simply, reference any of the below keys as you would any other site configuration value present in your `_config.yml` file, prefacing the key with `site.github`.
+
+For example, to list a project's name, you might write something like `The project is called {{ site.github.project_title }}` or to list an organization's open source repositories, you might use the following:
+
+```liquid
+{% for repository in site.github.public_repositories %}
+  * [{{ repository.name }}]({{ repository.html_url }})
+{% endfor %}
+```
+
+#### Available repository metadata
+
+The following sample information is exposed to Jekyll templates in the `site.github` namespace:
+
+```text
+{
+    "versions": {
+        "jekyll": <version>,
+        "kramdown": <version>,
+        "liquid": <version>,
+        "maruku": <version>,
+        "rdiscount": <version>,
+        "redcarpet": <version>,
+        "RedCloth": <version>,
+        "jemoji": <version>,
+        "jekyll-mentions": <version>,
+        "jekyll-redirect-from": <version>,
+        "jekyll-sitemap": <version>,
+        "github-pages": <version>,
+        "ruby": <version>"
+    },
+    "hostname": "github.com",
+    "pages_hostname": "github.io",
+    "api_url": "https://api.github.com",
+    "help_url": "https://help.github.com",
+    "environment": "dotcom",
+    "pages_env": "dotcom",
+    "public_repositories": [ Repository Objects ],
+    "organization_members": [ User Objects ],
+    "build_revision": "cbd866ebf142088896cbe71422b949de7f864bce",
+    "project_title": "metadata-example",
+    "project_tagline": "A GitHub Pages site to showcase repository metadata",
+    "owner_name": "github",
+    "owner_url": "https://github.com/github",
+    "owner_gravatar_url": "https://github.com/github.png",
+    "repository_url": "https://github.com/github/metadata-example",
+    "repository_nwo": "github/metadata-example",
+    "repository_name": "metadata-example",
+    "zip_url": "https://github.com/github/metadata-example/zipball/gh-pages",
+    "tar_url": "https://github.com/github/metadata-example/tarball/gh-pages",
+    "clone_url": "https://github.com/github/metadata-example.git",
+    "releases_url": "https://github.com/github/metadata-example/releases",
+    "issues_url": "https://github.com/github/metadata-example/issues",
+    "wiki_url": "https://github.com/github/metadata-example/wiki",
+    "language": null,
+    "is_user_page": false,
+    "is_project_page": true,
+    "show_downloads": true,
+    "url": "http://username.github.io/metadata-example", // (or the CNAME)
+    "baseurl": "/metadata-example",
+    "contributors": [ User Objects ],
+    "releases": [ Release Objects ],
+    "latest_release": [ Release Object ],
+    "private": false,
+    "license": {
+      "key": "mit",
+      "name": "MIT License",
+      "spdx_id": "MIT",
+      "url": "https://api.github.com/licenses/mit"
+    },
+    "source": {
+      "branch": "gh-pages",
+      "path": "/"
+    }
+}
+```


### PR DESCRIPTION
The GitHub Help Documentation has been updated and doesn't list these fields anymore. Since it belongs to this project, it makes sense to list them all here.

Much of this text is [borrowed directly from the GitHub Help Documentation](https://web.archive.org/web/20190616095556/https://help.github.com/en/articles/repository-metadata-on-github-pages). Credit goes to the wonderful Documentation team at GitHub for writing this up!