### PR TITLE
Add JEKYLL_ENV limitation for git remote

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,9 @@ be able to determine the repository NWO (name with owner, e.g. `jekyll/jekyll-gi
 The easiest way to accomplish this is by setting an "origin" remote with a
 github.com URL. If you ran `git clone` from GitHub, this is almost 100% the
 case & no further action is needed. If you run `git remote -v` in your
-repository, you should see your repo's URL.
+repository, you should see your repo's URL. However, this only works if the
+environment variable `JEKYLL_ENV` is either `development` or `test`.
+The default value of `JEKYLL_ENV` is `development`.
 
 If you don't have a git remote available, you have two other options:
 


### PR DESCRIPTION
Why
===
In order to find out the logic to configure NWO using `git remote` depends on `JEKYLL_ENV` easily.

What
===
I got the errors when I ran `JEKYLL_ENV=production bundle exec jekyll serve` for GitHub Pages.
The error is something like this.
```
  Liquid Exception: No repo name found. Specify using PAGES_REPO_NWO environment variables, 'repository' in your configuration, or set up an 'origin' git remote pointing to your github.com repository. in /_layouts/single.html
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    No repo name found. Specify using PAGES_REPO_NWO environment variables, 'repository' in your configuration, or set up an 'origin' git remote pointing to your github.com repository.
```

When I checked this code, I figured out that `git remote` is only checked if `JEKYLL_ENV` is either of `development` or `test` from the below code.
https://github.com/jekyll/github-metadata/blob/master/lib/jekyll-github-metadata/repository_finder.rb#L63

By the way, I'm a beginner for ruby, jekyll, and github pages, so please let me know something is wrong.

Related issues
===
* The comment from issue [91](https://github.com/jekyll/github-metadata/issues/91#issuecomment-274985642)