### PR TITLE
set PAGES_GITHUB_HOSTNAME to hostname without protocol

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,7 @@ Some `site.github` values can be overridden by environment variables.
 - `PAGES_ENV` – the `site.github.pages_env` (default: `development`)
 - `PAGES_API_URL` – the `site.github.api_url` (default: `https://api.github.com`)
 - `PAGES_HELP_URL` – the `site.github.help_url` (default: `https://help.github.com`)
-- `PAGES_GITHUB_HOSTNAME` – the `site.github.hostname` (default: `https://github.com`)
+- `PAGES_GITHUB_HOSTNAME` – the `site.github.hostname` (default: `github.com`)
 - `PAGES_PAGES_HOSTNAME` – the `site.github.pages_hostname` (default: `github.io`)
 - `NO_NETRC` – set if you don't want the fallback to `~/.netrc`
 


### PR DESCRIPTION
This PR sets the `PAGES_GITHUB_HOSTNAME` example to `github.com` without the protocol as GitHub pages also sets the `site.github.hostname` without the protocol.