### PR TITLE
Git-ignore the Jekyll cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg
 _site
 tmp
 *.gem
+.jekyll-cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
-.bundle
+.bundle/
+vendor/
 .tags*
 Gemfile.lock
 pkg
-_site
-tmp
+_site/
+tmp/
 *.gem
-.jekyll-cache
+.jekyll-cache/
+.jekyll-metadata


### PR DESCRIPTION
Resolve jekyll/github-metadata#199

Jekyll 4.x generates a cache when running the test suite. Prevent accidental commits.