### PR TITLE
Get path for first page of paginated pages (fixes #213)

### DIFF
--- a/lib/jekyll-github-metadata/edit-link-tag.rb
+++ b/lib/jekyll-github-metadata/edit-link-tag.rb
@@ -35,7 +35,6 @@ module Jekyll
       private def_hash_delegator :site_github, :source,         :source, {}
       private def_hash_delegator :source,      :branch,         :branch
       private def_hash_delegator :source,      :path,           :source_path
-      private def_hash_delegator :page,        :path,           :page_path
 
       def render(context)
         @context = context
@@ -70,6 +69,16 @@ module Jekyll
 
       def parts
         memoize_conditionally { [repository_url, "edit/", branch, source_path, page_path] }
+      end
+
+      def page_path
+        return page['path'] unless page['paginated']
+
+        site.pages.dup.select do |page|
+          if page.pager and page.pager.page == 1
+            return page['path']
+          end
+        end
       end
 
       def parts_normalized


### PR DESCRIPTION
When a page is paginated, the edit link includes the pagination part of the URL. This grabs the path from the first page of the pagination collection.

I would appreciate some help with the tests as I'm not familiar enough with Ruby.