### PR TITLE
Add site.github.public_repositories[].contributors

### DIFF
--- a/lib/jekyll-github-metadata/repository.rb
+++ b/lib/jekyll-github-metadata/repository.rb
@@ -119,6 +119,7 @@ module Jekyll
         }
         memoize_value :@owner_public_repositories, Value.new("owner_public_repositories", proc do |c|
           c.list_repos(owner, options).each { |r| r[:releases] = c.releases(r[:full_name]) }
+          c.list_repos(owner, options).each { |r| r[:contributors] = c.contributors(r[:full_name], options) }
         end)
       end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe("integration into a jekyll site") do
     expect(subject["public_repositories"].first["releases"].first["target_commitish"]).to eql("master")
   end
 
+  it "contains the correct public_repositories.contributors" do
+    expect(subject).to have_key("public_repositories")
+    expect(subject["public_repositories"].first).to have_key("contributors")
+    expect(subject["public_repositories"].first["contributors"].size).to eql(1)
+    expect(subject["public_repositories"].first["contributors"].first["login"]).to eql("parkr")
+    expect(subject["public_repositories"].first["contributors"].first["id"]).to eql(237985)
+  end
+
   it "calls all the stubs" do
     stubs.each do |stub|
       expect(stub).to have_been_requested

--- a/spec/spec_helpers/stub_helper.rb
+++ b/spec/spec_helpers/stub_helper.rb
@@ -23,6 +23,7 @@ module StubHelper
 
     owner_repos = JSON.parse(webmock_data("owner_repos"))
     owner_repos.each { |r| stubs << stub_api("/repos/#{r["full_name"]}/releases?per_page=100", "repo_releases") }
+    owner_repos.each { |r| stubs << stub_api("/repos/#{r["full_name"]}/contributors?per_page=100", "repo_contributors") }
 
     stubs
   end


### PR DESCRIPTION
Hello, 

After I wrote #233, I saw a merged PR about `site.github.public_repositories[].releases` (#224 by @parkr )

I've never used ruby before, but with help of my friend @peniar , I made this PR. (thanks, @peniar)

Here're what I did:

First, I changed the code `lib/jekyll-github-metadata/repository.rb` in my installed gem, and check it worked.

And then, I wrote some spec code referring previous PR about release, assumed that return should be like `spec/webmock/api_get_repo_contributors.json`

Lastly, I tested with `bundle exec rspec spec`, and then  1 test I added failed as follows:
```
Failures:

  1) integration into a jekyll site calls all the stubs
     Failure/Error: expect(stub).to have_been_requested

       The request GET https://api.github.com/repos/jekyll/github-metadata/contributors?per_page=100 with headers {'Accept'=>/application\/vnd\.github\.(v3|drax-preview|mercy-preview)\+json/, 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'token 1234abc', 'Content-Type'=>'application/json', 'User-Agent'=>'Octokit Ruby Gem 4.22.0'} was expected to execute 1 time but it executed 2 times
```

I think the error `expected to execute 1 time but it executed 2 times` is because the line 16 in stub_helper.rb conflict with line 26 which I added. However, line 15 for releases code does not conflict with line 25. :(

I'm stuck here and don't know what to try or look for anymore.

If you could point out this PR, I would be very grateful.