### PR TITLE
Inject `site.github` via `:pre_render` step rather than `:after_init`

### DIFF
--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -87,8 +87,7 @@ module Jekyll
     end
 
     Jekyll::Hooks.register :site, :after_init do |site|
-      SiteGitHubMunger.global_munger = \
-        SiteGitHubMunger.new(site)
+      SiteGitHubMunger.global_munger = SiteGitHubMunger.new(site)
       SiteGitHubMunger.global_munger.munge!
     end
 

--- a/lib/jekyll-github-metadata/site_github_munger.rb
+++ b/lib/jekyll-github-metadata/site_github_munger.rb
@@ -6,6 +6,10 @@ module Jekyll
     class SiteGitHubMunger
       extend Forwardable
 
+      class << self
+        attr_accessor :global_munger
+      end
+
       def_delegators Jekyll::GitHubMetadata, :site, :repository
       private :repository
 
@@ -16,11 +20,12 @@ module Jekyll
       def munge!
         Jekyll::GitHubMetadata.log :debug, "Initializing..."
 
-        # This is the good stuff.
-        site.config["github"] = github_namespace
-
         add_title_and_description_fallbacks!
         add_url_and_baseurl_fallbacks! if should_add_url_fallbacks?
+      end
+
+      def inject_metadata!(payload)
+        payload.site["github"] = github_namespace
       end
 
       private
@@ -80,9 +85,15 @@ module Jekyll
         site.config["name"] && !site.config["title"]
       end
     end
-  end
-end
 
-Jekyll::Hooks.register :site, :after_init do |site|
-  Jekyll::GitHubMetadata::SiteGitHubMunger.new(site).munge!
+    Jekyll::Hooks.register :site, :after_init do |site|
+      SiteGitHubMunger.global_munger = \
+        SiteGitHubMunger.new(site)
+      SiteGitHubMunger.global_munger.munge!
+    end
+
+    Jekyll::Hooks.register :site, :pre_render do |_site, payload|
+      SiteGitHubMunger.global_munger.inject_metadata!(payload)
+    end
+  end
 end


### PR DESCRIPTION
Jekyll 4 has a call to `site.config.inspect`, which renders all the values in `site.config['github']`.
This causes all of the API calls to be resolved regardless of whether the user is using them.
This patch should allow Jekyll 4 to call `site.config.inspect` without causing the large number of API calls.

Fixes #237.