### PR TITLE
Bump rubocop-jekyll to 0.13.0 and fix rubocop issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ AllCops:
     - vendor/**/*
     - script/*
 
+Style/FetchEnvVar:
+  Enabled: false
+
 Metrics/LineLength:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,10 +10,7 @@ AllCops:
     - vendor/**/*
     - script/*
 
-Style/FetchEnvVar:
-  Enabled: false
-
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/BlockLength:
@@ -25,6 +22,9 @@ Metrics/MethodLength:
     - spec/**/*
 
 Style/AccessModifierDeclarations:
+  Enabled: false
+
+Style/FetchEnvVar:
   Enabled: false
 
 Style/FrozenStringLiteralComment:

--- a/jekyll-github-metadata.gemspec
+++ b/jekyll-github-metadata.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.12.0"
-  spec.add_development_dependency "rubocop-jekyll", "~> 0.12.0"
+  spec.add_development_dependency "rubocop-jekyll", "~> 0.13.0"
 end

--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -130,11 +130,11 @@ module Jekyll
       def pluck_auth_method
         if ENV["JEKYLL_GITHUB_TOKEN"] || Octokit.access_token
           { :access_token => ENV["JEKYLL_GITHUB_TOKEN"] || Octokit.access_token }
-        elsif !ENV["NO_NETRC"] && File.exist?(File.join(ENV["HOME"], ".netrc")) && safe_require("netrc")
+        elsif !ENV["NO_NETRC"] && File.exist?(File.join(Dir.home, ".netrc")) && safe_require("netrc")
           { :netrc => true }
         else
-          GitHubMetadata.log :warn, "No GitHub API authentication could be found." \
-            " Some fields may be missing or have incorrect data."
+          GitHubMetadata.log :warn, "No GitHub API authentication could be found. " \
+                                    "Some fields may be missing or have incorrect data."
           {}.freeze
         end
       end

--- a/lib/jekyll-github-metadata/repository_finder.rb
+++ b/lib/jekyll-github-metadata/repository_finder.rb
@@ -27,9 +27,9 @@ module Jekyll
             nwo_from_git_origin_remote || \
             proc do
               raise NoRepositoryError, "No repo name found. " \
-                "Specify using PAGES_REPO_NWO environment variables, " \
-                "'repository' in your configuration, or set up an 'origin' " \
-                "git remote pointing to your github.com repository."
+                                       "Specify using PAGES_REPO_NWO environment variables, " \
+                                       "'repository' in your configuration, or set up an 'origin' " \
+                                       "git remote pointing to your github.com repository."
             end.call
         end
       end

--- a/spec/edit_link_tag_spec.rb
+++ b/spec/edit_link_tag_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Jekyll::GitHubMetadata::EditLinkTag do
 
   subject do
     tag = described_class.parse(tag_name, markup, tokenizer, parse_context)
-    tag.instance_variable_set("@context", render_context)
+    tag.instance_variable_set(:@context, render_context)
     tag
   end
 

--- a/spec/metadata_drop_spec.rb
+++ b/spec/metadata_drop_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe(Jekyll::GitHubMetadata::MetadataDrop) do
 
     context "with fallback data" do
       let(:fallback_data) { { "foo" => "bar" } }
-      before { subject.instance_variable_set("@fallback_data", fallback_data) }
+      before { subject.instance_variable_set(:@fallback_data, fallback_data) }
 
       it "returns the mutated value via #[]" do
         expect(subject["foo"]).to eql("bar")


### PR DESCRIPTION
I'm opening this PR in the hopes of helping move along a new release of `github-metadata`.

This has the same version bump of `rubocop-jekyll` as #251 but I also went ahead and let rubocop autocorrect the formatting issues it found.