### PR TITLE
Ignore HTTP 451 errors "Repository access blocked" when retrieving metadata

### DIFF
--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -95,7 +95,7 @@ module Jekyll
       rescue Faraday::ConnectionFailed, Octokit::TooManyRequests => e
         GitHubMetadata.log :warn, e.message
         default
-      rescue Octokit::NotFound
+      rescue Octokit::NotFound, Octokit::UnavailableForLegalReasons
         default
       end
 


### PR DESCRIPTION
GitHub returns 451 errors when trying to access any repository & forks that has been taken down for legal reason (e.g. DMCA Takedown).

Repositories in this situation are being frozen. Its not possible to access to their settings anymore and therefore not possible to delete them. Even through GitHub REST API. The only option to delete them is to open a ticket for GitHub support, which is likely to never be touched, for free accounts.

In case any one of your repositories or forks gets taken down for such reason, using the _jekyll-github-metadata_ plugin becomes impossible as the HTTP client fails as follow:

```
Liquid Exception: GET https://api.github.com/repos/USER/REPO/releases?per_page=100: 451 - Repository access blocked in _pages/page.md
rake aborted!

Octokit::UnavailableForLegalReasons: GET https://api.github.com/repos/USER/REPO/releases?per_page=100: 451 - Repository access blocked (Octokit::UnavailableForLegalReasons)
```

This change unblocks accounts in this situation and makes the `Octokit::UnavailableForLegalReasons` exception being ignored if it's encountered while retrieving repositories' metadata.