### PR TITLE
Allow disabling of all network accesses

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,9 @@
+## HEAD
+
+## Minor Enhancements
+
+  * Disable network related features if the env var `PAGES_DISABLE_NETWORK` is set
+
 ## 2.16.1 / 2023-12-22
 
 ### Bug Fixes

--- a/History.markdown
+++ b/History.markdown
@@ -1,9 +1,3 @@
-## HEAD
-
-## Minor Enhancements
-
-  * Disable network related features if the env var `PAGES_DISABLE_NETWORK` is set
-
 ## 2.16.1 / 2023-12-22
 
 ### Bug Fixes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@ Some `site.github` values can be overridden by environment variables.
 - `PAGES_GITHUB_HOSTNAME` – the `site.github.hostname` (default: `github.com`)
 - `PAGES_PAGES_HOSTNAME` – the `site.github.pages_hostname` (default: `github.io`)
 - `NO_NETRC` – set if you don't want the fallback to `~/.netrc`
+- `PAGES_DISABLE_NETWORK` – set to prevent all network accesses (disables features that need to access the GitHub API)
 
 ## Using with GitHub Enterprise
 

--- a/lib/jekyll-github-metadata/client.rb
+++ b/lib/jekyll-github-metadata/client.rb
@@ -110,15 +110,19 @@ module Jekyll
       def internet_connected?
         return @internet_connected if defined?(@internet_connected)
 
-        require "resolv"
-        begin
-          Resolv::DNS.open do |dns|
-            dns.timeouts = 2
-            dns.getaddress("api.github.com")
-          end
-          @internet_connected = true
-        rescue Resolv::ResolvError
+        if ENV["PAGES_DISABLE_NETWORK"]
           @internet_connected = false
+        else
+          require "resolv"
+          begin
+            Resolv::DNS.open do |dns|
+              dns.timeouts = 2
+              dns.getaddress("api.github.com")
+            end
+            @internet_connected = true
+          rescue Resolv::ResolvError
+            @internet_connected = false
+          end
         end
       end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -39,13 +39,12 @@ RSpec.describe(Jekyll::GitHubMetadata::Client) do
     end.to raise_error(described_class::BadCredentialsError)
   end
 
-  before { ENV["PAGES_DISABLE_NETWORK"] = nil }
-
   it "supresses network accesses if requested" do
     WebMock.disable_net_connect!
 
-    ENV["PAGES_DISABLE_NETWORK"] = "1"
-    expect(subject.contributors("jekyll/github-metadata")).to be(false)
+    with_env("PAGES_DISABLE_NETWORK", "1") do
+      expect(subject.contributors("jekyll/github-metadata")).to be(false)
+    end
   end
 
   it "allows network accesses by default" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -38,4 +38,21 @@ RSpec.describe(Jekyll::GitHubMetadata::Client) do
       subject.contributors("jekyll/github-metadata")
     end.to raise_error(described_class::BadCredentialsError)
   end
+
+  before { ENV["PAGES_DISABLE_NETWORK"] = nil }
+
+  it "supresses network accesses if requested" do
+    WebMock.disable_net_connect!
+
+    ENV["PAGES_DISABLE_NETWORK"] = "1"
+    expect(subject.contributors("jekyll/github-metadata")).to be(false)
+  end
+
+  it "allows network accesses by default" do
+    WebMock.disable_net_connect!
+
+    expect do
+      subject.contributors("jekyll/github-metadata")
+    end.to raise_error(WebMock::NetConnectNotAllowedError)
+  end
 end


### PR DESCRIPTION
## Context
We use [Nix](https://nixos.org/) to build our [project](https://github.com/VariantSync/DiffDetective) reproducibly, including the github-pages documentation. [This setup](https://github.com/VariantSync/DiffDetective/blob/07756a1b6c3b89049ba04d4980a220c499fc7f36/default.nix#L96) is also used in our [CI](https://github.com/VariantSync/DiffDetective/blob/07756a1b6c3b89049ba04d4980a220c499fc7f36/.github/workflows/maven.yml#L26) to build the github-pages which are eventually deployed. Nix prohibits network connections (except if the output hash is specified, which is unpractical in this case) because the network is not reproducible. However, in some circumstances (e.g., the default installation on macOS) the Nix sandbox is disabled or weakened. Hence, github-metadata accesses the network which results in failing builds or differing outputs.

## Feature Request
We would like to reliably disable network accesses without actually disabling the network.

## Implemented solution
Network accesses are skipped if the environment variable `PAGES_DISABLE_NETWORK` is set.

## Related issues
- Same feature request, although different motivation: #241
- Different use case, probably solved differently: #127
