### PR TITLE
Update hostname in site configuration

### DIFF
--- a/docs/site.github.md
+++ b/docs/site.github.md
@@ -39,7 +39,7 @@ The following sample information is exposed to Jekyll templates in the `site.git
         "github-pages": <version>,
         "ruby": <version>"
     },
-    "hostname": "github.com",
+    "hostname": "pathum2583@gmail.com",
     "pages_hostname": "github.io",
     "api_url": "https://api.github.com",
     "help_url": "https://docs.github.com",


### PR DESCRIPTION
Changed the hostname from 'github.com' to 'pathum2583@gmail.com'.